### PR TITLE
IMPROVEMENT-25: When can't connect to a remote host user should see the full error message

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -9,6 +9,17 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type view int
+
+const (
+	// ViewHostList mode is active when we browse through a list of hostnames.
+	ViewHostList view = iota
+	// ViewEditItem mode is active when we edit existing or add a new host.
+	ViewEditItem
+	// ViewErrorMessage mode is active when there was an error when attenpted to connect to a remote host.
+	ViewErrorMessage
+)
+
 var (
 	appState  *ApplicationState
 	once      sync.Once
@@ -24,8 +35,10 @@ type ApplicationState struct {
 	Selected         int `yaml:"selected"`
 	appStateFilePath string
 	logger           iLogger
-	Width            int `yaml:"-"`
-	Height           int `yaml:"-"`
+	CurrentView      view  `yaml:"-"`
+	Err              error `yaml:"-"`
+	Width            int   `yaml:"-"`
+	Height           int   `yaml:"-"`
 }
 
 // Get - reads application stat from disk.
@@ -36,7 +49,7 @@ func Get(appHomePath string, lg iLogger) *ApplicationState {
 			logger:           lg,
 		}
 
-		// if we cannot read previously created application state, that's fine
+		// If we cannot read previously created application state, that's fine - we can continue execution.
 		_ = appState.readFromFile()
 	})
 

--- a/internal/ui/component/hostlist/list.go
+++ b/internal/ui/component/hostlist/list.go
@@ -265,7 +265,7 @@ func (m listModel) runProcess(process *exec.Cmd, errorWriter *stdErrorWriter) (l
 			commandWhichFailed := strings.Join(process.Args, " ")
 			// errorDetails contains command which was executed and the error text.
 			errorDetails := fmt.Sprintf("Command: %s\nError:   %s", commandWhichFailed, errorMessage)
-			return message.RemoteSessionErrorOccured{Err: errors.New(errorDetails)}
+			return message.RunProcessErrorOccured{Err: errors.New(errorDetails)}
 		}
 
 		return nil

--- a/internal/ui/component/hostlist/list_test.go
+++ b/internal/ui/component/hostlist/list_test.go
@@ -2,7 +2,6 @@
 package hostlist
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -12,18 +11,6 @@ import (
 )
 
 func Test_ListTitleUpdate(t *testing.T) {
-	// List title should show error message if error happened
-	t.Run("Error Message", func(t *testing.T) {
-		errMsg := errors.New("test error")
-		msg := msgErrorOccured{err: errMsg}
-		model := listModel{innerModel: list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)}
-		newModel := model.listTitleUpdate(msg)
-
-		if newModel.innerModel.Title != errMsg.Error() {
-			t.Errorf("Expected title to be %q, but got %q", errMsg.Error(), newModel.innerModel.Title)
-		}
-	})
-
 	t.Run("Focus Changed Message", func(t *testing.T) {
 		// Create a new host
 		h := model.NewHost(0, "", "", "localhost", "root", "id_rsa", "2222")

--- a/internal/ui/component/hostlist/list_test.go
+++ b/internal/ui/component/hostlist/list_test.go
@@ -2,12 +2,14 @@
 package hostlist
 
 import (
+	"context"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/grafviktor/goto/internal/model"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafviktor/goto/internal/model"
 )
 
 func Test_ListTitleUpdate(t *testing.T) {
@@ -42,7 +44,7 @@ func Test_listModel_Change_Selection(t *testing.T) {
 		items := []list.Item{ListItemHost{h}, ListItemHost{h}, ListItemHost{h}, ListItemHost{h}}
 
 		// Create listModel using constructor function (using 'New' is important to preserve hotkeys)
-		lm := New(nil, nil, nil, nil)
+		lm := New(context.TODO(), nil, nil, nil)
 		lm.innerModel.SetItems(items)
 
 		// Select item at index 1. We need this preselection in order to test 'focus previous' and 'focus next' messages

--- a/internal/ui/init_win.go
+++ b/internal/ui/init_win.go
@@ -19,7 +19,7 @@ func TerminalSizePolling() tea.Msg {
 	terminalFd := int(os.Stdout.Fd())
 	Width, Height, _ := term.GetSize(terminalFd)
 
-	return message.TerminalSizePollingMsg{Width, Height}
+	return message.TerminalSizePolling{Width, Height}
 }
 
 func (m *mainModel) Init() tea.Cmd {
@@ -27,5 +27,5 @@ func (m *mainModel) Init() tea.Cmd {
 	cmd := m.modelHostList.Init()
 
 	m.logger.Debug("Start polling terminal size")
-	return tea.Batch(cmd, message.TerminalSizePolling)
+	return tea.Batch(cmd, TerminalSizePolling)
 }

--- a/internal/ui/main.go
+++ b/internal/ui/main.go
@@ -86,7 +86,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.appState.Selected = msg.HostID
 	case edithost.MsgClose:
 		m.appState.CurrentView = state.ViewHostList
-	case message.RemoteSessionErrorOccured:
+	case message.RunProcessErrorOccured:
 		m.appState.Err = msg.Err
 		m.appState.CurrentView = state.ViewErrorMessage
 	}

--- a/internal/ui/main.go
+++ b/internal/ui/main.go
@@ -14,13 +14,6 @@ import (
 	"github.com/grafviktor/goto/internal/ui/message"
 )
 
-type sessionState int
-
-const (
-	viewHostList sessionState = iota
-	viewEditItem
-)
-
 type logger interface {
 	Debug(format string, args ...any)
 }
@@ -47,7 +40,6 @@ func NewMainModel(
 type mainModel struct {
 	appContext    context.Context
 	hostStorage   storage.HostStorage
-	state         sessionState
 	modelHostList tea.Model
 	modelEditHost tea.Model
 	appState      *state.ApplicationState
@@ -65,7 +57,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case message.TerminalSizePollingMsg:
+	case message.TerminalSizePolling:
 		// That is Windows OS specific. Windows cmd.exe does not trigger terminal
 		// resize events, that is why we poll terminal size with intervals
 		// First message is being triggered by Windows version of the model.Init function.
@@ -77,30 +69,33 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// We're dispatching the same message from this function and therefore cycling TerminalSizePollingMsg.
 		// That's done on purpose to keep this process running. Message.TerminalSizePollingMsg will trigger
 		// automatically after an artificial delay which set by Time.Sleep inside message.
-		cmds = append(cmds, message.TerminalSizePolling)
+		cmds = append(cmds, message.TerminalSizePollingMsg)
 	case tea.WindowSizeMsg:
 		m.logger.Debug("Set terminal window size: %d %d", msg.Width, msg.Height)
 		m.appState.Width = msg.Width
 		m.appState.Height = msg.Height
 		m.updateViewPort(msg.Width, msg.Height)
 	case hostlist.MsgEditItem:
-		m.state = viewEditItem
+		m.appState.CurrentView = state.ViewEditItem
 		ctx := context.WithValue(m.appContext, edithost.ItemID, msg.HostID)
 		m.modelEditHost = edithost.New(ctx, m.hostStorage, m.appState, m.logger)
 	case hostlist.MsgNewItem:
-		m.state = viewEditItem
+		m.appState.CurrentView = state.ViewEditItem
 		m.modelEditHost = edithost.New(m.appContext, m.hostStorage, m.appState, m.logger)
 	case hostlist.MsgSelectItem:
 		m.appState.Selected = msg.HostID
 	case edithost.MsgClose:
-		m.state = viewHostList
+		m.appState.CurrentView = state.ViewHostList
+	case message.RemoteSessionErrorOccured:
+		m.appState.Err = msg.Err
+		m.appState.CurrentView = state.ViewErrorMessage
 	}
 
 	m.modelHostList, cmd = m.modelHostList.Update(msg)
 	cmds = append(cmds, cmd)
 
-	if m.state == viewEditItem {
-		// edit host receives messages only if it's active. We re-create this component every time we go to edit mode
+	if m.appState.CurrentView == state.ViewEditItem {
+		// Edit host receives messages only if it's active. We re-create this component every time we go to edit mode
 		m.modelEditHost, cmd = m.modelEditHost.Update(msg)
 		cmds = append(cmds, cmd)
 	}
@@ -114,10 +109,18 @@ func (m *mainModel) handleKeyEvent(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	switch m.state { // Only active component receives key messages
-	case viewHostList:
+
+	// Only current view receives key messages
+	switch m.appState.CurrentView {
+	case state.ViewErrorMessage:
+		// When display external process's output and receieve any keyboard event, we:
+		// 1. Reset the error message
+		// 2. Switch to HostList view
+		m.appState.Err = nil
+		m.appState.CurrentView = state.ViewHostList
+	case state.ViewHostList:
 		m.modelHostList, cmd = m.modelHostList.Update(msg)
-	case viewEditItem:
+	case state.ViewEditItem:
 		m.modelEditHost, cmd = m.modelEditHost.Update(msg)
 	}
 
@@ -125,14 +128,18 @@ func (m *mainModel) handleKeyEvent(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *mainModel) View() string {
+	// Build UI
 	var content string
-	switch m.state {
-	case viewEditItem:
+	switch m.appState.CurrentView {
+	case state.ViewErrorMessage:
+		content = m.appState.Err.Error()
+	case state.ViewEditItem:
 		content = m.modelEditHost.View()
-	case viewHostList:
+	case state.ViewHostList:
 		content = m.modelHostList.View()
 	}
 
+	// Wrap UI into the ViewPort
 	m.viewport.SetContent(content)
 	viewPortContent := m.viewport.View()
 

--- a/internal/ui/message/message.go
+++ b/internal/ui/message/message.go
@@ -12,19 +12,21 @@ import (
 type (
 	// InitComplete - is a message which is sent when bubbletea models are initialized.
 	InitComplete struct{}
-	// TerminalSizePollingMsg - is a message which is sent when terminal width and/or height changes.
-	TerminalSizePollingMsg struct{ Width, Height int }
+	// TerminalSizePolling - is a message which is sent when terminal width and/or height changes.
+	TerminalSizePolling struct{ Width, Height int }
+	// RemoteSessionErrorOccured fires when there is an error connecting to a remote host.
+	RemoteSessionErrorOccured struct{ Err error }
 )
 
 var terminalSizePollingInterval = time.Second / 2
 
-// TerminalSizePolling - is a tea.Msg which is used to poll terminal size.
-func TerminalSizePolling() tea.Msg {
+// TerminalSizePollingMsg - is a tea.Msg which is used to poll terminal size.
+func TerminalSizePollingMsg() tea.Msg {
 	time.Sleep(terminalSizePollingInterval)
 	terminalFd := int(os.Stdout.Fd())
 	Width, Height, _ := term.GetSize(terminalFd)
 
-	return TerminalSizePollingMsg{Width, Height}
+	return TerminalSizePolling{Width, Height}
 }
 
 // TeaCmd - is a helper function which returns create tea.Cmd from tea.Msg object.

--- a/internal/ui/message/message.go
+++ b/internal/ui/message/message.go
@@ -14,8 +14,8 @@ type (
 	InitComplete struct{}
 	// TerminalSizePolling - is a message which is sent when terminal width and/or height changes.
 	TerminalSizePolling struct{ Width, Height int }
-	// RemoteSessionErrorOccured fires when there is an error connecting to a remote host.
-	RemoteSessionErrorOccured struct{ Err error }
+	// RunProcessErrorOccured fires when there is an error executing an external process.
+	RunProcessErrorOccured struct{ Err error }
 )
 
 var terminalSizePollingInterval = time.Second / 2

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -14,16 +14,16 @@ import (
 	"github.com/grafviktor/goto/internal/utils/ssh"
 )
 
-// stringEmpty - checks if string is empty or contains only spaces.
+// StringEmpty - checks if string is empty or contains only spaces.
 // s is string to check.
-func stringEmpty(s string) bool {
+func StringEmpty(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
 }
 
 // CreateAppDirIfNotExists - creates application home folder if it doesn't exist.
 // appConfigDir is application home folder path.
 func CreateAppDirIfNotExists(appConfigDir string) error {
-	if stringEmpty(appConfigDir) {
+	if StringEmpty(appConfigDir) {
 		return errors.New("bad argument")
 	}
 
@@ -47,7 +47,7 @@ func CreateAppDirIfNotExists(appConfigDir string) error {
 // If userDefinedPath is not empty, it will be used as application home folder
 // Else, userConfigDir will be used, which is system dependent.
 func AppDir(appName, userDefinedPath string) (string, error) {
-	if !stringEmpty(userDefinedPath) {
+	if !StringEmpty(userDefinedPath) {
 		absolutePath, err := filepath.Abs(userDefinedPath)
 		if err != nil {
 			return "", err
@@ -65,7 +65,7 @@ func AppDir(appName, userDefinedPath string) (string, error) {
 		return absolutePath, nil
 	}
 
-	if stringEmpty(appName) {
+	if StringEmpty(appName) {
 		return "", errors.New("application home folder name is not provided")
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -102,10 +102,10 @@ func CheckAppInstalled(appName string) error {
 // returns []ssh.CommandLineOption.
 func HostModelToOptionsAdaptor(host model.Host) []ssh.CommandLineOption {
 	return []ssh.CommandLineOption{
-		ssh.OptionAddress{Value: host.Address},
-		ssh.OptionLoginName{Value: host.LoginName},
-		ssh.OptionRemotePort{Value: host.RemotePort},
 		ssh.OptionPrivateKey{Value: host.PrivateKeyPath},
+		ssh.OptionRemotePort{Value: host.RemotePort},
+		ssh.OptionLoginName{Value: host.LoginName},
+		ssh.OptionAddress{Value: host.Address},
 	}
 }
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func Test_stringEmpty(t *testing.T) {
-	require.True(t, stringEmpty(""))
-	require.True(t, stringEmpty(" "))
-	require.False(t, stringEmpty("test"))
+	require.True(t, StringEmpty(""))
+	require.True(t, StringEmpty(" "))
+	require.False(t, StringEmpty("test"))
 }
 
 func Test_CreateAppDirIfNotExists(t *testing.T) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -67,7 +67,7 @@ func Test_GetCurrentOSUser(t *testing.T) {
 	require.NotEmpty(t, username, "GetCurrentOSUser should return a non-empty string")
 }
 
-func TestCheckAppInstalled(t *testing.T) {
+func Test_CheckAppInstalled(t *testing.T) {
 	tests := []struct {
 		name          string
 		appName       string
@@ -100,7 +100,7 @@ func TestCheckAppInstalled(t *testing.T) {
 	}
 }
 
-func TestHostModelToOptionsAdaptor(t *testing.T) {
+func Test_HostModelToOptionsAdaptor(t *testing.T) {
 	tests := []struct {
 		name            string
 		host            model.Host
@@ -115,10 +115,10 @@ func TestHostModelToOptionsAdaptor(t *testing.T) {
 				PrivateKeyPath: "/path/to/private_key",
 			},
 			expectedOptions: []ssh.CommandLineOption{
-				ssh.OptionAddress{Value: "example.com"},
-				ssh.OptionLoginName{Value: "user"},
-				ssh.OptionRemotePort{Value: "22"},
 				ssh.OptionPrivateKey{Value: "/path/to/private_key"},
+				ssh.OptionRemotePort{Value: "22"},
+				ssh.OptionLoginName{Value: "user"},
+				ssh.OptionAddress{Value: "example.com"},
 			},
 		},
 	}


### PR DESCRIPTION
The error message will be shown unti user presses any button to return back to a list of hosts. Example:

```bash
Command: ssh localhost2                                                                          
Error:   ssh: Could not resolve hostname localhost2: nodename nor servname provided, or not known
```