### PR TITLE
When printing version information the application should display source branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-BUILD_VERSION=v0.3.0
-NO_DEBUG_FLAGS=-s -w
-LD_FLAGS = -ldflags="$(NO_DEBUG_FLAGS) -X main.buildVersion=$(BUILD_VERSION) -X main.buildDate=$(shell date +%Y-%m-%d) -X main.buildCommit=$(shell git rev-parse --short=8 HEAD)"
+BUILD_BRANCH  = $(shell git rev-parse --abbrev-ref HEAD)
+BUILD_COMMIT  = $(shell git rev-parse --short=8 HEAD)
+BUILD_VERSION = v0.4.0
+BUILD_DATE    = $(shell date +%Y-%m-%d)
+NO_DEBUG_FLAGS = -s -w
+# Check if there is no associated tag with this commit, that means that it is a dev build.
+BUILD_VERSION_SUFFIX = $(shell git describe --tags --exact-match > /dev/null 2>&1 || echo \\\(dev\\\))
+# Use build version and suffix for burning in buildVersion variable:
+# For tagged builds - "vX.X.X"
+# For non tagged - "vX.X.X (dev)"
+BUILD_VERSION_AND_SUFFIX = $(strip $(BUILD_VERSION) $(BUILD_VERSION_SUFFIX))
+LD_FLAGS = -ldflags="$(NO_DEBUG_FLAGS) -X main.buildVersion="$(BUILD_VERSION)$(BUILD_VERSION_SUFFIX)" -X main.buildDate=$(BUILD_DATE) -X main.buildCommit=$(BUILD_COMMIT) -X main.buildBranch=$(BUILD_BRANCH)"
 
 ## help: print this help message
 help:

--- a/cmd/goto/main.go
+++ b/cmd/goto/main.go
@@ -24,13 +24,14 @@ var (
 	buildVersion string
 	buildDate    string
 	buildCommit  string
+	buildBranch  string
 )
 
 const appName = "goto"
 
 func main() {
 	// Set application version and build details
-	version.Set(buildVersion, buildDate, buildCommit)
+	version.Set(buildVersion, buildCommit, buildBranch, buildDate)
 
 	environmentParams := config.User{}
 	// Command line parameters have higher precedence than other parameters, but lower than command line
@@ -85,6 +86,7 @@ func main() {
 	lg.Info("Start application")
 	lg.Info("Version:    %s", version.Number())
 	lg.Info("Commit:     %s", version.CommitHash())
+	lg.Info("Branch:     %s", version.BuildBranch())
 	lg.Info("Build date: %s", version.BuildDate())
 
 	ctx := context.Background()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,9 +6,10 @@ import (
 )
 
 type buildInfo struct {
-	number     string
-	date       string
-	commitHash string
+	number      string
+	date        string
+	commitHash  string
+	buildBranch string
 }
 
 var bi buildInfo
@@ -17,14 +18,15 @@ func init() {
 	valueIsNotAvailable := "N/A"
 
 	bi = buildInfo{
-		number:     valueIsNotAvailable,
-		date:       valueIsNotAvailable,
-		commitHash: valueIsNotAvailable,
+		number:      valueIsNotAvailable,
+		date:        valueIsNotAvailable,
+		commitHash:  valueIsNotAvailable,
+		buildBranch: valueIsNotAvailable,
 	}
 }
 
 // Set should be called from the main function to make application version details available for other app modules.
-func Set(buildVersion, buildDate, buildCommit string) {
+func Set(buildVersion, buildCommit, buildBranch, buildDate string) {
 	if len(buildVersion) > 0 {
 		bi.number = buildVersion
 	}
@@ -36,26 +38,36 @@ func Set(buildVersion, buildDate, buildCommit string) {
 	if len(buildCommit) > 0 {
 		bi.commitHash = buildCommit
 	}
+
+	if len(buildBranch) > 0 {
+		bi.buildBranch = buildBranch
+	}
 }
 
-// Number sets version of the application.
+// Number returns version of the application.
 func Number() string {
 	return bi.number
 }
 
-// BuildDate sets date of the build.
+// BuildDate returns date of the build.
 func BuildDate() string {
 	return bi.date
 }
 
-// CommitHash sets last commit id.
+// BuildBranch returns branch which was used to build the app.
+func BuildBranch() string {
+	return bi.buildBranch
+}
+
+// CommitHash returns last commit id which was used to build the app.
 func CommitHash() string {
 	return bi.commitHash
 }
 
-// Print - outputs build information right into terminal.
+// Print - outputs build information right into the terminal.
 func Print() {
 	fmt.Printf("Version:    %s\n", Number())
 	fmt.Printf("Commit:     %s\n", CommitHash())
+	fmt.Printf("Branch:     %s\n", BuildBranch())
 	fmt.Printf("Build date: %s\n", BuildDate())
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSetAndGet(t *testing.T) {
 	// Test Set function to update build information
-	Set("1.0", "2023-09-01", "abcdef")
+	Set("1.0", "abcdef", "develop", "2023-09-01")
 
 	// Check if the values are correctly updated
 	if Number() != "1.0" {
@@ -26,6 +26,10 @@ func TestSetAndGet(t *testing.T) {
 	if CommitHash() != "abcdef" {
 		t.Errorf("Expected BuildCommit() to return 'abcdef', but got '%s'", CommitHash())
 	}
+
+	if BuildBranch() != "develop" {
+		t.Errorf("Expected BuildBranch() to return 'develop', but got '%s'", BuildBranch())
+	}
 }
 
 func TestPrintConsole(t *testing.T) {
@@ -36,6 +40,7 @@ func TestPrintConsole(t *testing.T) {
 
 	expectedOutput := fmt.Sprintf("Version:    %s\n", Number())
 	expectedOutput += fmt.Sprintf("Commit:     %s\n", CommitHash())
+	expectedOutput += fmt.Sprintf("Branch:     %s\n", BuildBranch())
 	expectedOutput += fmt.Sprintf("Build date: %s\n", BuildDate())
 
 	require.Equal(t, output, expectedOutput)


### PR DESCRIPTION
Example:

```bash
$ gg -v
Version:    ...
Commit:     ...
Branch:     develop
Build date: ...

App home:  ....
```