### PR TITLE
IMPROVEMENT-24: Validate user input when add or change a host

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
       - name: Test
-        run: go test -coverpkg=$(go list ./internal/...|grep -v mock) -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
+        run: go test -coverpkg=$(go list ./internal/..|grep -v mock) -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
       - name: Test
-        run: go test -coverpkg=./internal/... -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
+        run: go test -coverpkg=$(go list ./internal/...|grep -v mock) -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,8 @@ run:
   # skip-files:
   #    - ".*\\.my\\.go$"
   #    - lib/bad.go
-
+  skip-dirs:
+    - internal/mock
 
 # output configuration options
 output:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,7 +127,7 @@ linters:
   disable-all: true
   enable:
     #    - cyclop
-    - depguard
+    #    - depguard
     - dogsled
     #    - dupl
     - errcheck
@@ -153,7 +153,6 @@ linters:
     #    - gosec
     - gosimple
     - govet
-    - depguard
     #    - ifshort
     #    - ireturn
     - lll

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ audit:
 	go mod tidy
 	go mod verify
 	@echo 'Formatting code...'
-	gofumpt -l -w ./..
+	gofumpt -l -w -extra ./
 	goimports -w -local github.com/grafviktor/goto .
 	@echo 'Vetting code...'
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ audit:
 .PHONY: test
 test:
 	@echo 'Running unit tests'
-	go test -coverpkg=$(go list ./internal/...|grep -v mock) -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
+# By using -coverpkg=$$(go list ./internal/..|grep -v mock) we exclude "mock" folder from codecov report
+	go test -coverpkg=$$(go list ./internal/..|grep -v mock) -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
 
 ## unit-test-report: display unit coverage report in html format
 .PHONY: unit-test-report

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ audit:
 .PHONY: test
 test:
 	@echo 'Running unit tests'
-	go test -coverpkg=./internal/... -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
+	go test -coverpkg=$(go list ./internal/...|grep -v mock) -race -vet=off -count=1 -coverprofile unit.txt -covermode atomic ./...
 
 ## unit-test-report: display unit coverage report in html format
 .PHONY: unit-test-report

--- a/internal/mock/logger.go
+++ b/internal/mock/logger.go
@@ -1,0 +1,15 @@
+package mock
+
+type MockLogger struct{}
+
+func (l *MockLogger) Debug(format string, args ...any) {
+}
+
+func (l *MockLogger) Info(format string, args ...any) {
+}
+
+func (l *MockLogger) Error(format string, args ...any) {
+}
+
+func (l *MockLogger) Close() {
+}

--- a/internal/mock/storage.go
+++ b/internal/mock/storage.go
@@ -1,0 +1,65 @@
+package mock
+
+import (
+	"errors"
+
+	"github.com/grafviktor/goto/internal/model"
+)
+
+// =============================================== Storage
+
+func NewMockStorage(shouldFail bool) *mockStorage {
+	hosts := []model.Host{
+		model.NewHost(0, "Mock Host", "", "localhost", "root", "id_rsa", "2222"),
+		model.NewHost(0, "Mock Host", "", "localhost", "root", "id_rsa", "2222"),
+		model.NewHost(0, "Mock Host", "", "localhost", "root", "id_rsa", "2222"),
+	}
+
+	return &mockStorage{
+		shouldFail: shouldFail,
+		Hosts:      hosts,
+	}
+}
+
+type mockStorage struct {
+	shouldFail bool
+	Hosts      []model.Host
+}
+
+// Delete implements storage.HostStorage.
+func (ms *mockStorage) Delete(id int) error {
+	if ms.shouldFail {
+		return errors.New("mock error")
+	}
+
+	ms.Hosts = append(ms.Hosts[:id], ms.Hosts[id+1:]...)
+
+	return nil
+}
+
+// Get implements storage.HostStorage.
+func (ms *mockStorage) Get(hostID int) (model.Host, error) {
+	if ms.shouldFail {
+		return model.Host{}, errors.New("mock error")
+	}
+
+	return model.Host{}, nil
+}
+
+// GetAll implements storage.HostStorage.
+func (ms *mockStorage) GetAll() ([]model.Host, error) {
+	if ms.shouldFail {
+		return ms.Hosts, errors.New("mock error")
+	}
+
+	return ms.Hosts, nil
+}
+
+// Save implements storage.HostStorage.
+func (ms *mockStorage) Save(m model.Host) (model.Host, error) {
+	if ms.shouldFail {
+		return m, errors.New("mock error")
+	}
+
+	return m, nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -12,7 +12,7 @@ import (
 type HostStorage interface {
 	GetAll() ([]model.Host, error)
 	Get(hostID int) (model.Host, error)
-	Save(model.Host) error
+	Save(model.Host) (model.Host, error)
 	Delete(id int) error
 }
 

--- a/internal/storage/yaml_storage.go
+++ b/internal/storage/yaml_storage.go
@@ -72,7 +72,7 @@ func (s *yamlStorage) flushToDisk() error {
 	return nil
 }
 
-func (s *yamlStorage) Save(host model.Host) error {
+func (s *yamlStorage) Save(host model.Host) (model.Host, error) {
 	if host.ID == idEmpty {
 		s.nextID++
 		host.ID = s.nextID
@@ -80,7 +80,7 @@ func (s *yamlStorage) Save(host model.Host) error {
 
 	s.innerStorage[host.ID] = yamlHostWrapper{host}
 
-	return s.flushToDisk()
+	return host, s.flushToDisk()
 }
 
 func (s *yamlStorage) Delete(id int) error {

--- a/internal/ui/component/edithost/edit_host.go
+++ b/internal/ui/component/edithost/edit_host.go
@@ -4,6 +4,7 @@ package edithost
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -41,6 +42,26 @@ type logger interface {
 	Debug(format string, args ...any)
 }
 
+func notEmptyValidator(s string) error {
+	if utils.StringEmpty(s) {
+		return fmt.Errorf("value is required")
+	}
+
+	return nil
+}
+
+func networkPortValidator(s string) error {
+	if utils.StringEmpty(s) {
+		return nil
+	}
+
+	if num, err := strconv.ParseInt(s, 10, 16); err != nil || num < 1 {
+		return fmt.Errorf("network port must be a number which is less than 65 535")
+	}
+
+	return nil
+}
+
 // New - returns new edit host form.
 func New(ctx context.Context, storage storage.HostStorage, state *state.ApplicationState, log logger) editModel {
 	// if we can't cast host id to int, that means we're adding a new host. Ignoring the error
@@ -71,10 +92,12 @@ func New(ctx context.Context, storage storage.HostStorage, state *state.Applicat
 			t.Label = "Title"
 			t.Focus()
 			t.SetValue(host.Title)
+			t.Validate = notEmptyValidator
 		case 1:
 			t.Label = "IP Address or Hostname"
 			t.CharLimit = 128
 			t.SetValue(host.Address)
+			t.Validate = notEmptyValidator
 		case 2:
 			t.Label = "Description"
 			t.CharLimit = 512
@@ -89,6 +112,7 @@ func New(ctx context.Context, storage storage.HostStorage, state *state.Applicat
 			t.CharLimit = 5
 			t.Placeholder = "default: 22"
 			t.SetValue(host.RemotePort)
+			t.Validate = networkPortValidator
 		case 5:
 			t.Label = "Identity file path"
 			t.CharLimit = 512

--- a/internal/ui/component/edithost/edit_host.go
+++ b/internal/ui/component/edithost/edit_host.go
@@ -70,7 +70,7 @@ func networkPortValidator(s string) error {
 	auto := 0 // 0 is used to autodetect base, see strconv.ParseUint
 	maxLengthBit := 16
 	if num, err := strconv.ParseUint(s, auto, maxLengthBit); err != nil || num < 1 {
-		return fmt.Errorf("network port must be a number which is less than 65 535")
+		return fmt.Errorf("network port must be a number which is less than 65,535")
 	}
 
 	return nil
@@ -248,9 +248,15 @@ func (m editModel) save(_ tea.Msg) (editModel, tea.Cmd) {
 	}
 
 	host, _ := m.hostStorage.Save(m.host)
-	return m, tea.Batch(
+	// Need to check storage error and update application status:
+	// if err !=nil { return message.TeaCmd(message.Error{Err: err}) }
+	// or
+	// m.title = err
+
+	return m, tea.Sequence(
 		message.TeaCmd(MsgClose{}),
-		// Order matters here! 'HostListSelectItem' message should be dispatched
+		// Order matters here! That's why we use tea.Sequence instead of tea.Batch.
+		// 'HostListSelectItem' message should be dispatched
 		// before 'MsgRepoUpdated'. The reasons of that is because
 		// 'MsgRepoUpdated' handler automatically sets focus on previously selected item.
 		message.TeaCmd(message.HostListSelectItem{HostID: host.ID}),

--- a/internal/ui/component/edithost/edit_host_keymap.go
+++ b/internal/ui/component/edithost/edit_host_keymap.go
@@ -5,14 +5,15 @@ import (
 )
 
 type keyMap struct {
-	Up      key.Binding
-	Down    key.Binding
-	Save    key.Binding
-	Discard key.Binding
+	Up          key.Binding
+	Down        key.Binding
+	Save        key.Binding
+	CopyToTitle key.Binding
+	Discard     key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Save, k.Discard}
+	return []key.Binding{k.Up, k.Down, k.Save, k.CopyToTitle, k.Discard}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
@@ -31,6 +32,10 @@ var keys = keyMap{
 	Save: key.NewBinding(
 		key.WithKeys("ctrl+s"),
 		key.WithHelp("ctrl+s", "save"),
+	),
+	CopyToTitle: key.NewBinding(
+		key.WithKeys("alt+enter"),
+		key.WithHelp("alt+enter", "copy to title"),
 	),
 	Discard: key.NewBinding(
 		key.WithKeys("esc"),

--- a/internal/ui/component/edithost/edit_host_test.go
+++ b/internal/ui/component/edithost/edit_host_test.go
@@ -1,0 +1,159 @@
+// Package edithost contains UI components for editing host model attributes.
+package edithost
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafviktor/goto/internal/mock"
+	"github.com/grafviktor/goto/internal/state"
+)
+
+func Test_NotEmptyValidator(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected error
+	}{
+		{"", fmt.Errorf("value is required")},
+		{"non-empty", nil},
+	}
+
+	for _, test := range tests {
+		result := notEmptyValidator(test.input)
+
+		if (result == nil && test.expected != nil) || (result != nil && test.expected == nil) {
+			t.Errorf("For input %q, expected error %v but got %v", test.input, test.expected, result)
+		}
+
+		if result != nil && result.Error() != test.expected.Error() {
+			t.Errorf("For input %q, expected error %v but got %v", test.input, test.expected, result)
+		}
+	}
+}
+
+func Test_NetworkPortValidator(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected error
+	}{
+		{"", nil},
+		{"abc", fmt.Errorf("network port must be a number which is less than 65,535")},
+		{"0", fmt.Errorf("network port must be a number which is less than 65,535")},
+		{"65536", fmt.Errorf("network port must be a number which is less than 65,535")},
+		{"123", nil},
+	}
+
+	for _, test := range tests {
+		result := networkPortValidator(test.input)
+
+		if (result == nil && test.expected != nil) || (result != nil && test.expected == nil) {
+			t.Errorf("For input %q, expected error %v but got %v", test.input, test.expected, result)
+		}
+
+		if result != nil && result.Error() != test.expected.Error() {
+			t.Errorf("For input %q, expected error %v but got %v", test.input, test.expected, result)
+		}
+	}
+}
+
+func Test_GetKeyMap(t *testing.T) {
+	keyMap := getKeyMap(inputAddress)
+	require.True(t, keyMap.CopyToTitle.Enabled())
+
+	keyMap = getKeyMap(inputTitle)
+	require.False(t, keyMap.CopyToTitle.Enabled())
+}
+
+func Test_New(t *testing.T) {
+	state := state.ApplicationState{}
+
+	// If we open host details, but host does not exist, we should focus Address input by default
+	editHostModel := New(context.TODO(), mock.NewMockStorage(true), &state, &mock.MockLogger{})
+	require.Equal(t, inputAddress, editHostModel.focusedInput)
+
+	// If we open host details, but host does not exist, we should focus Title input by default
+	editHostModel = New(context.TODO(), mock.NewMockStorage(false), &state, &mock.MockLogger{})
+	require.Equal(t, inputTitle, editHostModel.focusedInput)
+}
+
+// func (m editModel) save(_ tea.Msg) (editModel, tea.Cmd) {
+// 	for i := range m.inputs {
+// 		if m.inputs[i].Validate != nil {
+// 			if err := m.inputs[i].Validate(m.inputs[i].Value()); err != nil {
+// 				m.inputs[i].Err = err
+// 				m.title = fmt.Sprintf("%s is not valid", m.inputs[i].Label)
+
+// 				return m, nil
+// 			}
+// 		}
+
+// 		switch i {
+// 		case inputTitle:
+// 			m.host.Title = m.inputs[i].Value()
+// 		case inputAddress:
+// 			m.host.Address = m.inputs[i].Value()
+// 		case inputDescription:
+// 			m.host.Description = m.inputs[i].Value()
+// 		case inputLogin:
+// 			m.host.LoginName = m.inputs[i].Value()
+// 		case inputNetworkPort:
+// 			m.host.RemotePort = m.inputs[i].Value()
+// 		case inputIdentityFile:
+// 			m.host.PrivateKeyPath = m.inputs[i].Value()
+// 		}
+// 	}
+
+// 	host, _ := m.hostStorage.Save(m.host)
+// 	return m, tea.Batch(
+// 		message.TeaCmd(MsgClose{}),
+// 		// Order matters here! 'HostListSelectItem' message should be dispatched
+// 		// before 'MsgRepoUpdated'. The reasons of that is because
+// 		// 'MsgRepoUpdated' handler automatically sets focus on previously selected item.
+// 		message.TeaCmd(message.HostListSelectItem{HostID: host.ID}),
+// 		message.TeaCmd(hostlist.MsgRepoUpdated{}),
+// 	)
+// }
+
+func Test_save(t *testing.T) {
+	state := state.ApplicationState{}
+
+	editHostModel := New(context.TODO(), mock.NewMockStorage(true), &state, &mock.MockLogger{})
+	require.Equal(t, inputAddress, editHostModel.focusedInput)
+
+	editHostModel.inputs[inputDescription].SetValue("test")
+	editHostModel.inputs[inputLogin].SetValue("root")
+	editHostModel.inputs[inputNetworkPort].SetValue("2222")
+	editHostModel.inputs[inputIdentityFile].SetValue("id_rsa")
+
+	// Should fail because mandatory fields are not set
+	model, messageSequence := editHostModel.save(nil)
+
+	require.Nil(t, messageSequence)
+	require.Contains(t, model.title, "not valid")
+
+	// model, messageSequence := editHostModel.save(nil)
+
+	editHostModel.inputs[inputTitle].SetValue("test")
+	editHostModel.inputs[inputAddress].SetValue("localhost")
+
+	model, messageSequence = editHostModel.save(nil)
+
+	require.NotNil(t, messageSequence)
+
+	/*
+		// Cannot test return values because the function returns an array-like structure of private objects
+		expectedSequence := tea.Sequence(
+			message.TeaCmd(MsgClose{}),
+			message.TeaCmd(message.HostListSelectItem{HostID: model.host.ID}),
+			message.TeaCmd(hostlist.MsgRepoUpdated{}),
+		)
+
+		one := expectedSequence()
+		two := messageSequence() // returns []tea.sequenceMsg, which is private. Cannot test.
+
+		require.Equal(t, one, two)
+	*/
+}

--- a/internal/ui/component/edithost/label_input.go
+++ b/internal/ui/component/edithost/label_input.go
@@ -33,12 +33,14 @@ type labeledInput struct {
 	FocusedLabelStyle lipgloss.Style
 	FocusedInputStyle lipgloss.Style
 	FocusedPrompt     string
+	Err               error
 }
 
 func (l labeledInput) Update(msg tea.Msg) (labeledInput, tea.Cmd) {
 	var cmd tea.Cmd
 
 	l.Model, cmd = l.Model.Update(msg)
+	l.Err = l.Model.Err
 
 	return l, cmd
 }
@@ -62,7 +64,11 @@ func (l labeledInput) labelView() string {
 func (l labeledInput) View() string {
 	var view string
 	if l.Focused() {
-		view = lipgloss.NewStyle().Foreground(lipgloss.Color("#AD58B4")).Render(l.Model.View())
+		if l.Err != nil {
+			view = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF7783")).Render(l.Model.Err.Error())
+		} else {
+			view = lipgloss.NewStyle().Foreground(lipgloss.Color("#AD58B4")).Render(l.Model.View())
+		}
 	} else {
 		view = l.Model.View()
 	}

--- a/internal/ui/component/edithost/label_input.go
+++ b/internal/ui/component/edithost/label_input.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // NewLabelInput - component which consists from input and label.
@@ -16,26 +15,16 @@ func NewLabelInput() labeledInput {
 	inputModel.Prompt = ""
 
 	return labeledInput{
-		Model:             inputModel,
-		FocusedPrompt:     "│ ",
-		LabelStyle:        noStyle,
-		InputStyle:        noStyle,
-		FocusedLabelStyle: focusedStyle,
-		FocusedInputStyle: focusedStyle,
-		ErrorStyle:        errorStyle,
+		Model:         inputModel,
+		FocusedPrompt: "│ ",
 	}
 }
 
 type labeledInput struct {
 	textinput.Model
-	Label             string
-	LabelStyle        lipgloss.Style
-	InputStyle        lipgloss.Style
-	FocusedLabelStyle lipgloss.Style
-	FocusedInputStyle lipgloss.Style
-	ErrorStyle        lipgloss.Style
-	FocusedPrompt     string
-	Err               error
+	Label         string
+	FocusedPrompt string
+	Err           error
 }
 
 func (l labeledInput) Update(msg tea.Msg) (labeledInput, tea.Cmd) {
@@ -52,7 +41,7 @@ func (l labeledInput) Update(msg tea.Msg) (labeledInput, tea.Cmd) {
 
 func (l labeledInput) prompt() string {
 	if l.Focused() {
-		return l.FocusedLabelStyle.Render(l.FocusedPrompt)
+		return focusedStyle.Render(l.FocusedPrompt)
 	}
 
 	return strings.Repeat(" ", utf8.RuneCountInString(l.FocusedPrompt))
@@ -60,25 +49,19 @@ func (l labeledInput) prompt() string {
 
 func (l labeledInput) labelView() string {
 	if l.Err != nil {
-		return l.prompt() + l.ErrorStyle.Render(l.Label)
+		return l.prompt() + errorStyle.Render(l.Label)
 	} else if l.Focused() {
-		return l.prompt() + l.FocusedLabelStyle.Render(l.Label)
+		return l.prompt() + focusedStyle.Render(l.Label)
 	}
 
-	return l.prompt() + l.LabelStyle.Render(l.Label)
+	return l.prompt() + noStyle.Render(l.Label)
 }
 
 func (l labeledInput) View() string {
 	var view string
 	if l.Focused() {
-		view = lipgloss.NewStyle().Foreground(lipgloss.Color("#AD58B4")).Render(l.Model.View())
+		view = focusedInputText.Render(l.Model.View())
 	} else {
-		// if l.Err != nil {
-		// 	view = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF7783")).Render(l.Err.Error())
-		// } else {
-		// 	view = l.Model.View()
-		// }
-
 		view = l.Model.View()
 	}
 

--- a/internal/ui/component/edithost/style.go
+++ b/internal/ui/component/edithost/style.go
@@ -10,8 +10,9 @@ var (
 	errorStyle = lipgloss.NewStyle().
 			BorderForeground(lipgloss.AdaptiveColor{Light: "#F793FF", Dark: "#AD58B4"}).
 			Foreground(lipgloss.AdaptiveColor{Light: "#FF7783", Dark: "#FF7783"})
-	cursorStyle = focusedStyle.Copy()
-	noStyle     = lipgloss.NewStyle()
+	cursorStyle      = focusedStyle.Copy()
+	focusedInputText = lipgloss.NewStyle().Foreground(lipgloss.Color("#AD58B4"))
+	noStyle          = lipgloss.NewStyle()
 
 	titleStyle = lipgloss.NewStyle().
 			Background(lipgloss.Color("62")).

--- a/internal/ui/component/edithost/style.go
+++ b/internal/ui/component/edithost/style.go
@@ -7,6 +7,9 @@ var (
 	focusedStyle = lipgloss.NewStyle().
 			BorderForeground(lipgloss.AdaptiveColor{Light: "#F793FF", Dark: "#AD58B4"}).
 			Foreground(lipgloss.AdaptiveColor{Light: "#EE6FF8", Dark: "#EE6FF8"})
+	errorStyle = lipgloss.NewStyle().
+			BorderForeground(lipgloss.AdaptiveColor{Light: "#F793FF", Dark: "#AD58B4"}).
+			Foreground(lipgloss.AdaptiveColor{Light: "#FF7783", Dark: "#FF7783"})
 	cursorStyle = focusedStyle.Copy()
 	noStyle     = lipgloss.NewStyle()
 

--- a/internal/ui/component/hostlist/list.go
+++ b/internal/ui/component/hostlist/list.go
@@ -38,8 +38,6 @@ type (
 	MsgEditItem struct{ HostID int }
 	// MsgCopyItem fires when user press copy button.
 	MsgCopyItem struct{ HostID int }
-	// MsgSelectItem is required to let host list know that it's time to update title.
-	MsgSelectItem struct{ HostID int }
 	// MsgNewItem fires when user press new host button.
 	MsgNewItem      struct{}
 	msgInitComplete struct{}
@@ -269,7 +267,7 @@ func (m listModel) copyItem(_ tea.Msg) (listModel, tea.Cmd) {
 		}
 	}
 
-	if err := m.repo.Save(clonedHost); err != nil {
+	if _, err := m.repo.Save(clonedHost); err != nil {
 		return m, message.TeaCmd(msgErrorOccured{err})
 	}
 
@@ -342,7 +340,7 @@ func (m listModel) listTitleUpdate() listModel {
 
 func (m listModel) onFocusChanged(_ tea.Msg) (listModel, tea.Cmd) {
 	if hostItem, ok := m.innerModel.SelectedItem().(ListItemHost); ok {
-		return m, message.TeaCmd(MsgSelectItem{HostID: hostItem.ID})
+		return m, message.TeaCmd(message.HostListSelectItem{HostID: hostItem.ID})
 	}
 
 	return m, nil

--- a/internal/ui/component/hostlist/list_test.go
+++ b/internal/ui/component/hostlist/list_test.go
@@ -375,10 +375,10 @@ func (ms *mockStorage) GetAll() ([]model.Host, error) {
 }
 
 // Save implements storage.HostStorage.
-func (ms *mockStorage) Save(model.Host) error {
+func (ms *mockStorage) Save(m model.Host) (model.Host, error) {
 	if ms.shouldFail {
-		return errors.New("Mock error")
+		return m, errors.New("Mock error")
 	}
 
-	return nil
+	return m, nil
 }

--- a/internal/ui/component/hostlist/list_test.go
+++ b/internal/ui/component/hostlist/list_test.go
@@ -3,7 +3,6 @@ package hostlist
 
 import (
 	"context"
-	"errors"
 	"os"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafviktor/goto/internal/model"
+	"github.com/grafviktor/goto/internal/mock"
 	"github.com/grafviktor/goto/internal/utils"
 )
 
@@ -308,14 +307,14 @@ func Test_listTitleUpdate(t *testing.T) {
 // ============================================== List Model
 
 func NewMockListModel(storageShouldFail bool) *listModel {
-	storage := NewMockStorage(storageShouldFail)
+	storage := mock.NewMockStorage(storageShouldFail)
 
 	// Create listModel using constructor function (using 'New' is important to preserve hotkeys)
 	lm := New(context.TODO(), storage, nil, nil)
 
 	items := make([]list.Item, 0)
 	// Wrap hosts into List items
-	hosts := storage.hosts
+	hosts := storage.Hosts
 	for _, h := range hosts {
 		items = append(items, ListItemHost{Host: h})
 	}
@@ -323,62 +322,4 @@ func NewMockListModel(storageShouldFail bool) *listModel {
 	lm.innerModel.SetItems(items)
 
 	return &lm
-}
-
-// =============================================== Storage
-
-func NewMockStorage(shouldFail bool) *mockStorage {
-	hosts := []model.Host{
-		model.NewHost(0, "Mock Host", "", "localhost", "root", "id_rsa", "2222"),
-		model.NewHost(0, "Mock Host", "", "localhost", "root", "id_rsa", "2222"),
-		model.NewHost(0, "Mock Host", "", "localhost", "root", "id_rsa", "2222"),
-	}
-
-	return &mockStorage{
-		shouldFail: shouldFail,
-		hosts:      hosts,
-	}
-}
-
-type mockStorage struct {
-	shouldFail bool
-	hosts      []model.Host
-}
-
-// Delete implements storage.HostStorage.
-func (ms *mockStorage) Delete(id int) error {
-	if ms.shouldFail {
-		return errors.New("Mock error")
-	}
-
-	ms.hosts = append(ms.hosts[:id], ms.hosts[id+1:]...)
-
-	return nil
-}
-
-// Get implements storage.HostStorage.
-func (ms *mockStorage) Get(hostID int) (model.Host, error) {
-	if ms.shouldFail {
-		return model.Host{}, errors.New("Mock error")
-	}
-
-	return model.Host{}, nil
-}
-
-// GetAll implements storage.HostStorage.
-func (ms *mockStorage) GetAll() ([]model.Host, error) {
-	if ms.shouldFail {
-		return ms.hosts, errors.New("Mock error")
-	}
-
-	return ms.hosts, nil
-}
-
-// Save implements storage.HostStorage.
-func (ms *mockStorage) Save(m model.Host) (model.Host, error) {
-	if ms.shouldFail {
-		return m, errors.New("Mock error")
-	}
-
-	return m, nil
 }

--- a/internal/ui/main.go
+++ b/internal/ui/main.go
@@ -82,7 +82,7 @@ func (m *mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case hostlist.MsgNewItem:
 		m.appState.CurrentView = state.ViewEditItem
 		m.modelEditHost = edithost.New(m.appContext, m.hostStorage, m.appState, m.logger)
-	case hostlist.MsgSelectItem:
+	case message.HostListSelectItem:
 		m.appState.Selected = msg.HostID
 	case edithost.MsgClose:
 		m.appState.CurrentView = state.ViewHostList

--- a/internal/ui/message/message.go
+++ b/internal/ui/message/message.go
@@ -16,6 +16,8 @@ type (
 	TerminalSizePolling struct{ Width, Height int }
 	// RunProcessErrorOccured fires when there is an error executing an external process.
 	RunProcessErrorOccured struct{ Err error }
+	// HostListSelectItem is required to let host list know that it's time to update title.
+	HostListSelectItem struct{ HostID int }
 )
 
 var terminalSizePollingInterval = time.Second / 2


### PR DESCRIPTION
Mark title and address input fields if user didn't provide any value;
When user creates a new host, then title is based on the hostname. Hostname input is focused by default;
User can only choose from range 1-65535 when provides remote server's ssh port.

In progress still. TODO: add test coverage, remove unwanted comments, run linter.