### PR TITLE
IMPROVEMENT-44: Create Dockerfile for deb package build process. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Ignore build folder
-build/dist
+# Ignore dist folder
+dist/
 
 # Dependency directories (remove the comment below to include it)
 vendor/
@@ -30,7 +30,7 @@ unit.txt
 .vscode
 
 # Application temporary files and configs
-/goto
+goto/
 
 # Temporary project files
 *.svg

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_VERSION_SUFFIX = $(shell git describe --tags --exact-match > /dev/null 2>&
 # For non tagged - "vX.X.X (dev)"
 BUILD_VERSION_AND_SUFFIX = $(strip $(BUILD_VERSION) $(BUILD_VERSION_SUFFIX))
 LD_FLAGS = -ldflags="$(NO_DEBUG_FLAGS) -X main.buildVersion="$(BUILD_VERSION)$(BUILD_VERSION_SUFFIX)" -X main.buildDate=$(BUILD_DATE) -X main.buildCommit=$(BUILD_COMMIT) -X main.buildBranch=$(BUILD_BRANCH)"
-BUILD_OUTPUT_PATH=./build/dist
+DIST_PATH=./dist
 
 ## help: print this help message
 help:
@@ -62,28 +62,30 @@ run:
 ## build: create binary in ./build/dist folder for your current platform. Use this option if you build it for personal use.
 .PHONY: build
 build:
-	@-rm -r $(BUILD_OUTPUT_PATH)/gg
+	@-rm -r $(DIST_PATH)/gg
 	@echo 'Building'
-	go build $(LD_FLAGS) -o $(BUILD_OUTPUT_PATH)/gg ./cmd/goto/*.go
+	go build $(LD_FLAGS) -o $(DIST_PATH)/gg ./cmd/goto/*.go
 
 ## package: create rpm package and place it into ./build/dist folder.
 .PHONY: package
 package:
-	@-rm -r $(BUILD_OUTPUT_PATH)/*.rpm
+	@-rm -r $(DIST_PATH)/*.rpm $(DIST_PATH)/*.deb
 	@echo 'Build rpm package'
 # Use cut to convert version from 'vX.X.X' to 'X.X.X'
-	@DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/rpm/Dockerfile --output build/dist .
+	@DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/rpm/Dockerfile --output ./dist .
+	@echo 'Build deb package'
+	@DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/deb/Dockerfile --output ./dist .
 
 ## dist: create binaries for all supported platforms in ./build/dist folder. Archive all binaries with zip.
 .PHONY: dist
 dist:
-	@-rm -r $(BUILD_OUTPUT_PATH)/gg-*
-	@-rm -r $(BUILD_OUTPUT_PATH)/*.zip
+	@-rm -r $(DIST_PATH)/gg-*
+	@-rm -r $(DIST_PATH)/*.zip
 	@echo 'Creating binary files'
-	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build $(LD_FLAGS) -o $(BUILD_OUTPUT_PATH)/gg-mac     ./cmd/goto/*.go
-	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build $(LD_FLAGS) -o $(BUILD_OUTPUT_PATH)/gg-lin     ./cmd/goto/*.go
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LD_FLAGS) -o $(BUILD_OUTPUT_PATH)/gg-win.exe ./cmd/goto/*.go
-	@mkdir $(BUILD_OUTPUT_PATH)/goto-$(BUILD_VERSION)/
-	@cp $(BUILD_OUTPUT_PATH)/gg* $(BUILD_OUTPUT_PATH)/goto-$(BUILD_VERSION)
-	@cd $(BUILD_OUTPUT_PATH) && zip -r goto-$(BUILD_VERSION).zip goto-$(BUILD_VERSION)
-	@rm -r $(BUILD_OUTPUT_PATH)/goto-$(BUILD_VERSION)
+	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build $(LD_FLAGS) -o $(DIST_PATH)/gg-mac     ./cmd/goto/*.go
+	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build $(LD_FLAGS) -o $(DIST_PATH)/gg-lin     ./cmd/goto/*.go
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LD_FLAGS) -o $(DIST_PATH)/gg-win.exe ./cmd/goto/*.go
+	@mkdir $(DIST_PATH)/goto-$(BUILD_VERSION)/
+	@cp $(DIST_PATH)/gg-mac $(DIST_PATH)/gg-lin $(DIST_PATH)/gg-win.exe $(DIST_PATH)/goto-$(BUILD_VERSION)
+	@cd $(DIST_PATH) && zip -r goto-$(BUILD_VERSION).zip goto-$(BUILD_VERSION)
+	@rm -r $(DIST_PATH)/goto-$(BUILD_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -59,28 +59,29 @@ run:
 	@echo 'To pass app arguments use: make run ARGS="-h"'
 	go run cmd/goto/* $(ARGS)
 
-## build: create binary in ./build/dist folder for your current platform. Use this option if you build it for personal use.
+## build: create binary in ./dist folder for your current platform. Use this option if you build it for personal use.
 .PHONY: build
 build:
-	@-rm -r $(DIST_PATH)/gg
+	@-rm -r $(DIST_PATH)/gg 2>/dev/null
 	@echo 'Building'
 	go build $(LD_FLAGS) -o $(DIST_PATH)/gg ./cmd/goto/*.go
 
-## package: create rpm package and place it into ./build/dist folder.
+## package: create rpm and deb packages and place them into ./dist folder.
 .PHONY: package
 package:
-	@-rm -r $(DIST_PATH)/*.rpm $(DIST_PATH)/*.deb
+	@-rm -r $(DIST_PATH)/*.rpm $(DIST_PATH)/*.deb 2>/dev/null
 	@echo 'Build rpm package'
 # Use cut to convert version from 'vX.X.X' to 'X.X.X'
-	@DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/rpm/Dockerfile --output ./dist .
+# Set branch to 'BRANCH=master' if want
+	@DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/rpm/Dockerfile --output ./dist .
 	@echo 'Build deb package'
-	@DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/deb/Dockerfile --output ./dist .
+	@DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build --build-arg VERSION=$(shell echo $(BUILD_VERSION) | cut -c 2-) -f build/deb/Dockerfile --output ./dist .
 
-## dist: create binaries for all supported platforms in ./build/dist folder. Archive all binaries with zip.
+## dist: create binaries for all supported platforms in ./dist folder. Archive all binaries with zip.
 .PHONY: dist
 dist:
-	@-rm -r $(DIST_PATH)/gg-*
-	@-rm -r $(DIST_PATH)/*.zip
+	@-rm -r $(DIST_PATH)/gg-* 2>/dev/null
+	@-rm -r $(DIST_PATH)/*.zip 2>/dev/null
 	@echo 'Creating binary files'
 	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build $(LD_FLAGS) -o $(DIST_PATH)/gg-mac     ./cmd/goto/*.go
 	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build $(LD_FLAGS) -o $(DIST_PATH)/gg-lin     ./cmd/goto/*.go

--- a/build/deb/Dockerfile
+++ b/build/deb/Dockerfile
@@ -1,26 +1,29 @@
+# Build stage
 FROM debian:12.4 as deb-build-stage
-
 ARG VERSION
 ENV CGO_ENABLED=0
 ENV WORK_DIR="/build"
-ENV PACKAGE_SRC_ROOT="${WORK_DIR}/goto_${VERSION}_x86_64"
-
+ENV PACKAGE_SRC_ROOT="${WORK_DIR}/goto_${VERSION}_amd64"
 RUN apt update && apt install git build-essential golang-go -y
-ADD build/deb/goto.control build/deb/preinst /tmp/
 WORKDIR "$WORK_DIR"
 RUN \
-  git clone --depth 1 --branch v%{_version} https://github.com/grafviktor/goto.git . && \
-  make build && \
+  git clone --depth 1 --branch v${VERSION} https://github.com/grafviktor/goto.git . && \
+  make build
+ADD build/deb/goto.control /tmp/
+RUN \
   mkdir -p ${PACKAGE_SRC_ROOT}/DEBIAN && \
-  cp /tmp/preinst ${PACKAGE_SRC_ROOT}/DEBIAN && \
   cp /tmp/goto.control ${PACKAGE_SRC_ROOT}/DEBIAN/control && \
+  sed -i "s/%VERSION%/$VERSION/g" ${PACKAGE_SRC_ROOT}/DEBIAN/control && \
   mkdir -p ${PACKAGE_SRC_ROOT}/usr/bin && \
-  cp ./build/dist/gg ${PACKAGE_SRC_ROOT}/usr/bin && \
-  cd "$PACKAGE_SRC_ROOT" && \
-  dpkg-deb --build && \
-  dpkg -i goto-${VERSION}.x86_64.deb && \
+  cp ./dist/gg ${PACKAGE_SRC_ROOT}/usr/bin && \
+  dpkg-deb -v --build "${WORK_DIR}/goto_${VERSION}_amd64"
+RUN \
+  dpkg -i goto_${VERSION}_amd64.deb && \
   gg -v
 
+
+# Export stage
 FROM scratch AS export-stage
 ARG VERSION
-COPY --from=deb-build-stage /root/rpmbuild/RPMS/x86_64/goto-${VERSION}.x86_64.rpm .
+ENV WORK_DIR="/build"
+COPY --from=deb-build-stage ${WORK_DIR}/goto_${VERSION}_amd64.deb .

--- a/build/deb/Dockerfile
+++ b/build/deb/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:12.4 as deb-build-stage
+
+ARG VERSION
+ENV CGO_ENABLED=0
+ENV WORK_DIR="/build"
+ENV PACKAGE_SRC_ROOT="${WORK_DIR}/goto_${VERSION}_x86_64"
+
+RUN apt update && apt install git build-essential golang-go -y
+ADD build/deb/goto.control build/deb/preinst /tmp/
+WORKDIR "$WORK_DIR"
+RUN \
+  git clone --depth 1 --branch v%{_version} https://github.com/grafviktor/goto.git . && \
+  make build && \
+  mkdir -p ${PACKAGE_SRC_ROOT}/DEBIAN && \
+  cp /tmp/preinst ${PACKAGE_SRC_ROOT}/DEBIAN && \
+  cp /tmp/goto.control ${PACKAGE_SRC_ROOT}/DEBIAN/control && \
+  mkdir -p ${PACKAGE_SRC_ROOT}/usr/bin && \
+  cp ./build/dist/gg ${PACKAGE_SRC_ROOT}/usr/bin && \
+  cd "$PACKAGE_SRC_ROOT" && \
+  dpkg-deb --build && \
+  dpkg -i goto-${VERSION}.x86_64.deb && \
+  gg -v
+
+FROM scratch AS export-stage
+ARG VERSION
+COPY --from=deb-build-stage /root/rpmbuild/RPMS/x86_64/goto-${VERSION}.x86_64.rpm .

--- a/build/deb/goto.control
+++ b/build/deb/goto.control
@@ -1,0 +1,7 @@
+Package: goto
+Version: %VERSION%
+Architecture: amd64
+Essential: no
+Priority: optional
+Maintainer: Roman Leonenkov
+Description: This utility helps to maintain a list of ssh servers. Unlike PuTTY it doesn't incorporate any connection logic, but relying on openssh package which should be installed on your system.

--- a/build/deb/goto.control
+++ b/build/deb/goto.control
@@ -3,5 +3,5 @@ Version: %VERSION%
 Architecture: amd64
 Essential: no
 Priority: optional
-Maintainer: Roman Leonenkov
+Maintainer: Roman Leonenkov <6890447+grafviktor@users.noreply.github.com>
 Description: This utility helps to maintain a list of ssh servers. Unlike PuTTY it doesn't incorporate any connection logic, but relying on openssh package which should be installed on your system.

--- a/build/deb/preinst
+++ b/build/deb/preinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Set package version in debian control file
+sed -i 's|%VERSION%|$PACKAGE_SRC_ROOT/control|g' control

--- a/build/deb/preinst
+++ b/build/deb/preinst
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# Set package version in debian control file
-sed -i 's|%VERSION%|$PACKAGE_SRC_ROOT/control|g' control

--- a/build/rpm/Dockerfile
+++ b/build/rpm/Dockerfile
@@ -12,13 +12,13 @@
 # dnf remove goto
 # rpm --verbose --erase hello
 
-FROM almalinux:9.3-20231124 as build-stage
+FROM almalinux:9.3-20231124 as rpm-build-stage
 
 ARG VERSION
 RUN yum install -y rpmdevtools rpmlint golang git
 ADD build/rpm/goto.spec /tmp/
 RUN rpmdev-setuptree && \
-  # rpmbuild should use XZ compression for packages, to avoid "rpmlib(PayloadIsZstd) <= 5.4.18-1" is needed error
+  # rpmbuild should use XZ compression for packages, to avoid "rpmlib(PayloadIsZstd) <= 5.4.18-1 is needed" error
   echo '%_binary_payload w2.xzdio' > ~/.rpmmacros && \
   cp /tmp/goto.spec ~/rpmbuild/SPECS/ && \
   # spectool is used to download source code
@@ -28,7 +28,7 @@ RUN rpmdev-setuptree && \
   gg -v
 
 # Copy from build container to host file system.
-# Ensure that DOCKER_BUILDKIT=1 and docker build has parameter: --output build/dist
+# Ensure that DOCKER_BUILDKIT=1 and docker build has parameter: --output ./dist
 FROM scratch AS export-stage
 ARG VERSION
-COPY --from=build-stage /root/rpmbuild/RPMS/x86_64/goto-${VERSION}.x86_64.rpm .
+COPY --from=rpm-build-stage /root/rpmbuild/RPMS/x86_64/goto-${VERSION}.x86_64.rpm .

--- a/build/rpm/Dockerfile
+++ b/build/rpm/Dockerfile
@@ -1,19 +1,5 @@
-
-# Verify the package has been installed
-# rpm -qi goto
-#
-# See changelog
-# rpm -q goto --changelog
-#
-# See what’s in the RPM package
-# rpm -ql goto
-#
-# Remove the RPM package
-# dnf remove goto
-# rpm --verbose --erase hello
-
+# Build stage
 FROM almalinux:9.3-20231124 as rpm-build-stage
-
 ARG VERSION
 RUN yum install -y rpmdevtools rpmlint golang git
 ADD build/rpm/goto.spec /tmp/
@@ -27,6 +13,7 @@ RUN rpmdev-setuptree && \
   rpm -ivh ~/rpmbuild/RPMS/x86_64/goto-${VERSION}.x86_64.rpm && \
   gg -v
 
+# Export stage
 # Copy from build container to host file system.
 # Ensure that DOCKER_BUILDKIT=1 and docker build has parameter: --output ./dist
 FROM scratch AS export-stage

--- a/build/rpm/goto.spec
+++ b/build/rpm/goto.spec
@@ -1,16 +1,15 @@
 # Warning: you run "echo '%_binary_payload w2.xzdio' > ~/.rpmmacros" before running rpmbuild. #
 # That should be done to use an old compression method to avoid newer rpmlib dependency.      #
 
-Name:           goto
-Version:        %{_version}
-Release:        1%{?dist}
-Summary:        GOTO - A simple command line SSH manager
-ExclusiveArch:  x86_64
-BuildRequires:  golang
-Group:          Applications/System
-
-License:        MIT
-Source0:        https://github.com/grafviktor/goto/archive/refs/tags/v%{_version}.tar.gz
+Name:          goto
+Version:       %{_version}
+Release:       1%{?dist}
+Summary:       GOTO - A simple command line SSH manager
+ExclusiveArch: x86_64
+BuildRequires: golang
+Group:         Applications/System
+License:       MIT
+Source0:       https://github.com/grafviktor/goto/archive/refs/tags/v%{_version}.tar.gz
 
 # Define a file name without using RH release version in resulting package suffix
 %define _rpmfilename %%{ARCH}/%{NAME}-%%{VERSION}.%%{ARCH}.rpm
@@ -22,7 +21,7 @@ This utility helps to maintain a list of ssh servers. Unlike PuTTY it doesn't in
 
 %prep
 rm -rf rpmbuild/BUILD/{,.[!.],..?}*
-git clone https://github.com/grafviktor/goto.git .
+git clone --depth 1 --branch v%{_version} https://github.com/grafviktor/goto.git .
 
 %build
 # To avoid clib dependency and make this package portable across distributions, disable cgo
@@ -32,7 +31,7 @@ make build
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/%{_bindir}
-cp ./build/dist/gg $RPM_BUILD_ROOT/%{_bindir}
+cp ./dist/gg $RPM_BUILD_ROOT/%{_bindir}
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
- Now `make dist` creates dist packages in `PROJECT_ROOT/dist` instead of `PROJECT_ROOT/build/dist`
- Add a set of instructions and a `Dockerfile` for creating a deb package