### PR TITLE
BUGFIX-49: Should not propagate value from title to address in saved hosts

### DIFF
--- a/internal/ui/component/edithost/edit_host_keymap.go
+++ b/internal/ui/component/edithost/edit_host_keymap.go
@@ -5,15 +5,15 @@ import (
 )
 
 type keyMap struct {
-	Up            key.Binding
-	Down          key.Binding
-	Save          key.Binding
-	CopyToAddress key.Binding
-	Discard       key.Binding
+	Up             key.Binding
+	Down           key.Binding
+	Save           key.Binding
+	CopyInputValue key.Binding
+	Discard        key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Save, k.CopyToAddress, k.Discard}
+	return []key.Binding{k.Up, k.Down, k.Save, k.CopyInputValue, k.Discard}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
@@ -33,9 +33,9 @@ var keys = keyMap{
 		key.WithKeys("ctrl+s"),
 		key.WithHelp("ctrl+s", "save"),
 	),
-	CopyToAddress: key.NewBinding(
+	CopyInputValue: key.NewBinding(
 		key.WithKeys("alt+enter"),
-		key.WithHelp("alt+enter", "copy to address"),
+		key.WithHelp("alt+enter", "title ↔ host"),
 	),
 	Discard: key.NewBinding(
 		key.WithKeys("esc"),

--- a/internal/ui/component/edithost/edit_host_test.go
+++ b/internal/ui/component/edithost/edit_host_test.go
@@ -225,15 +225,32 @@ func TestHandleCopyInputValueShortcut(t *testing.T) {
 	model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	// Confirm that 'Title' value is 'test123' and 'Address' hasn't changed
-	assert.Equal(t, "test123", model.inputs[inputTitle].Value())
-	assert.Equal(t, "test", model.inputs[inputAddress].Value())
+	require.Equal(t, "test123", model.inputs[inputTitle].Value())
+	require.Equal(t, "test", model.inputs[inputAddress].Value())
 	// Now press the shortcut which will copy Title value to Address
-	// That's failing: need to use model.Update instead of directly calling handleCopyInputValueShortcut function
-	// updated, _ := model.Update(model.keyMap.CopyInputValue.Keys())
-	// assert.Equal(t, "test123", updated.(editModel).inputs[inputTitle].Value())
-	// assert.Equal(t, "test123", updated.(editModel).inputs[inputAddress].Value())
-	model.handleCopyInputValueShortcut()
+	model.Update(tea.KeyMsg{
+		Type: tea.KeyEnter,
+		Alt:  true,
+	})
 	// Confirm that 'Title' and 'Host' values are now equal top 'test123'
 	assert.Equal(t, "test123", model.inputs[inputTitle].Value())
 	assert.Equal(t, "test123", model.inputs[inputAddress].Value())
+
+	// Then select address input and append '456', so the value will be test123456
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Equal(t, inputAddress, updated.(editModel).focusedInput)
+	updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	// Check that title still preserves value 'teste123' and address was updated
+	assert.Equal(t, "test123", updated.(editModel).inputs[inputTitle].Value())
+	assert.Equal(t, "test123456", updated.(editModel).inputs[inputAddress].Value())
+	// Now press the shortcut which will copy Address value to Title
+	updated.Update(tea.KeyMsg{
+		Type: tea.KeyEnter,
+		Alt:  true,
+	})
+	// Ensure that 'Title' and 'Host' values are now equal top 'test123456'
+	assert.Equal(t, "test123456", model.inputs[inputTitle].Value())
+	assert.Equal(t, "test123456", model.inputs[inputAddress].Value())
 }

--- a/internal/ui/component/edithost/edit_host_test.go
+++ b/internal/ui/component/edithost/edit_host_test.go
@@ -62,13 +62,15 @@ func Test_NetworkPortValidator(t *testing.T) {
 }
 
 func Test_GetKeyMap(t *testing.T) {
-	// When title is selected, we can copy its value into address field using keyboard shortcut
+	// When title or address is selected, we can copy its values between each other using a shortcut
 	keyMap := getKeyMap(inputTitle)
-	require.True(t, keyMap.CopyToAddress.Enabled())
+	require.True(t, keyMap.CopyInputValue.Enabled())
+	keyMap = getKeyMap(inputTitle)
+	require.True(t, keyMap.CopyInputValue.Enabled())
 
-	// However, when any other input selected, this keyboard shortcut should NOT be avaiable.
-	keyMap = getKeyMap(inputAddress)
-	require.False(t, keyMap.CopyToAddress.Enabled())
+	// However, when any other input selected, this keyboard shortcut should NOT be available.
+	keyMap = getKeyMap(inputDescription)
+	require.False(t, keyMap.CopyInputValue.Enabled())
 }
 
 // func (m editModel) save(_ tea.Msg) (editModel, tea.Cmd) {


### PR DESCRIPTION
 - Disable automatic value copying from title input to address when host already exist in the database. 
 - Allow to copy between title and address using shortcut.
 
In progress.