### PR TITLE
BUGFIX-58: When filtering items, initial host order should be preserved

### DIFF
--- a/internal/ui/component/hostlist/hostlist.go
+++ b/internal/ui/component/hostlist/hostlist.go
@@ -66,9 +66,16 @@ type listModel struct {
 func New(_ context.Context, storage storage.HostStorage, appState *state.ApplicationState, log logger) *listModel {
 	delegate := list.NewDefaultDelegate()
 	delegateKeys := newDelegateKeyMap()
+
 	var listItems []list.Item
+	innerModel := list.New(listItems, delegate, 0, 0)
+	// This line affects sorting when filtering enabled. What UnsortedFilter
+	// does - it filters the collection, but leaves initial items order unchanged.
+	// Default filter on the contrary - filters the collection based on the match rank.
+	innerModel.Filter = list.UnsortedFilter
+
 	m := listModel{
-		innerModel: list.New(listItems, delegate, 0, 0),
+		innerModel: innerModel,
 		keyMap:     delegateKeys,
 		repo:       storage,
 		appState:   appState,


### PR DESCRIPTION
Change default filter to 'UnsortedFilter' in host list UI model.