### PR TITLE
BUGFIX-75: Should properly parse custom commands containing quotes

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -84,7 +84,34 @@ func CheckAppInstalled(appName string) error {
 	return err
 }
 
-var argumentsRegexp = regexp.MustCompile(`\s+`)
+func splitArguments(cmd string) []string {
+	args := make([]string, 0)
+	inQuotes := false
+	commandLength := len(cmd)
+
+	var arg string
+	for charIndex, ch := range cmd {
+		isQuoteCharacter := ch == '"' || ch == '\''
+		isSpaceCharacter := ch == ' '
+
+		switch {
+		case isSpaceCharacter && !inQuotes:
+			args = append(args, arg)
+			arg = ""
+		case isQuoteCharacter:
+			inQuotes = !inQuotes
+		default:
+			arg += string(ch)
+		}
+
+		isLastCharacter := charIndex == commandLength-1
+		if isLastCharacter {
+			args = append(args, arg)
+		}
+	}
+
+	return args
+}
 
 // BuildProcess - builds exec.Cmd object from command string.
 func BuildProcess(cmd string) *exec.Cmd {
@@ -92,7 +119,7 @@ func BuildProcess(cmd string) *exec.Cmd {
 		return nil
 	}
 
-	commandWithArguments := argumentsRegexp.Split(cmd, -1)
+	commandWithArguments := splitArguments(cmd)
 	command := commandWithArguments[0]
 	arguments := commandWithArguments[1:]
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -84,6 +84,12 @@ func CheckAppInstalled(appName string) error {
 	return err
 }
 
+// splitArguments - converts a command with arguments into an array of strings.
+// Note, that it does not preserves inner quote characters:
+//
+//	ssh -o option="123 456"
+//	// will be split into 3 this array:
+//	"ssh" "-o" "option=123 456" // no quotes around 123 456
 func splitArguments(cmd string) []string {
 	args := make([]string, 0)
 	inQuotes := false

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -162,3 +162,18 @@ func TestBuildLoadSSHConfig(t *testing.T) {
 	require.Equal(t, &ProcessBufferWriter{}, cmd.Stderr)
 	require.Equal(t, &ProcessBufferWriter{}, cmd.Stdout)
 }
+
+func TestSplitArguments(t *testing.T) {
+	arguments := `ssh user@127.0.0.1 -o ProxyCommand="/usr/bin/nc -x 127.0.0.1:9689 %h %p" -i /Users/roman/.ssh/id_rsa`
+	expected := []string{
+		"ssh",
+		"user@127.0.0.1",
+		"-o",
+		"ProxyCommand=/usr/bin/nc -x 127.0.0.1:9689 %h %p",
+		"-i",
+		"/Users/roman/.ssh/id_rsa",
+	}
+
+	actual := splitArguments(arguments)
+	require.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Resolves the custom command parsing issue when a command contains quotes. See [issue/75](https://github.com/grafviktor/goto/issues/75) for the details.