### PR TITLE
Add Homebrew installation instructions for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Supported platforms: macOS, Linux, Windows.
 
 #### Debian or RedHat ####
 
-RPM and DEB packages are available in the releases section (these packages are not provided for pre-release builds).
+RPM and DEB packages are available in the [releases](https://github.com/grafviktor/goto/releases/latest) section (these packages are not provided for pre-release builds).
 
-#### Arch Linux ####
+#### Arch Linux (AUR) ####
 
-Package [goto-ssh-bin](https://aur.archlinux.org/packages/goto-ssh-bin) is supported by Arch Linux community. Please find the details in [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=goto-ssh-bin) file.
+_Maintained externally by the open-source community._
+
+Install [goto-ssh-bin](https://aur.archlinux.org/packages/goto-ssh-bin) package. Also see the [build](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=goto-ssh-bin) file for additional details.
 
 ```bash
 # Install goto
@@ -36,6 +38,8 @@ yay -S goto-ssh-bin
 ```
 
 #### macOS (Homebrew) ####
+
+_Maintained externally by the open-source community._
 
 You can install `goto` via Homebrew using a community tap:
 


### PR DESCRIPTION
Hello! I noticed that there wasn’t a Homebrew option in the installation instructions, so I created a [custom Homebrew tap](https://github.com/avasilic/homebrew-goto) to make it easier for macOS users to install and keep `goto` up to date.

This PR adds a small section to the README under **"1.2 Using package manager"** showing how to install `goto` with:

```bash
brew tap avasilic/goto
brew install goto-ssh
```

This installs the CLI as `gg`, so users can run it right away with `gg`.