### PR TITLE
Explicitly define ssh command in `hosts.yaml`

### DIFF
--- a/internal/model/host/host.go
+++ b/internal/model/host/host.go
@@ -11,6 +11,7 @@ import (
 
 // Host model definition.
 type Host struct {
+	Command          string                   `yaml:"command,omitempty"`
 	Address          string                   `yaml:"address"`
 	Description      string                   `yaml:"description,omitempty"`
 	Group            string                   `yaml:"group,omitempty"`
@@ -26,6 +27,7 @@ type Host struct {
 // NewHost - constructs new Host model.
 func NewHost(id int, title, description, address, loginName, identityFilePath, remotePort string) Host {
 	return Host{
+		Command:          "ssh",
 		ID:               id,
 		Title:            title,
 		Description:      description,
@@ -39,6 +41,7 @@ func NewHost(id int, title, description, address, loginName, identityFilePath, r
 // Clone host model.
 func (h *Host) Clone() Host {
 	newHost := Host{
+		Command:          h.Command,
 		Title:            h.Title,
 		Group:            h.Group,
 		Description:      h.Description,
@@ -66,16 +69,16 @@ func (h *Host) IsUserDefinedSSHCommand() bool {
 // CmdSSHConnect - returns SSH command for connecting to a remote host.
 func (h *Host) CmdSSHConnect() string {
 	if h.IsUserDefinedSSHCommand() {
-		return sshcommand.ConnectCommand(sshcommand.OptionAddress{Value: h.Address})
+		return sshcommand.ConnectCommand(h.Command, sshcommand.OptionAddress{Value: h.Address})
 	}
 
 	if h.StorageType == constant.HostStorageType.SSHConfig {
 		// When it's SSHConfig storage type, we need to use the title as a host name.
 		// This is because the by addressing the host by alias, we get all its settings from ssh_config.
-		return sshcommand.ConnectCommand(sshcommand.OptionAddress{Value: h.Title})
+		return sshcommand.ConnectCommand(h.Command, sshcommand.OptionAddress{Value: h.Title})
 	}
 
-	return sshcommand.ConnectCommand([]sshcommand.Option{
+	return sshcommand.ConnectCommand(h.Command, []sshcommand.Option{
 		sshcommand.OptionPrivateKey{Value: h.IdentityFilePath},
 		sshcommand.OptionRemotePort{Value: h.RemotePort},
 		sshcommand.OptionLoginName{Value: h.LoginName},
@@ -86,14 +89,14 @@ func (h *Host) CmdSSHConnect() string {
 // CmdSSHConfig - returns SSH command for loading host default configuration.
 func (h *Host) CmdSSHConfig() string {
 	if h.StorageType == constant.HostStorageType.SSHConfig {
-		return sshcommand.LoadConfigCommand(sshcommand.OptionReadHostConfig{Value: h.Title})
+		return sshcommand.LoadConfigCommand(h.Command, sshcommand.OptionReadHostConfig{Value: h.Title})
 	}
 
 	if h.IsUserDefinedSSHCommand() {
-		return sshcommand.LoadConfigCommand(sshcommand.OptionReadHostConfig{Value: h.Address})
+		return sshcommand.LoadConfigCommand(h.Command, sshcommand.OptionReadHostConfig{Value: h.Address})
 	}
 
-	return sshcommand.LoadConfigCommand([]sshcommand.Option{
+	return sshcommand.LoadConfigCommand(h.Command, []sshcommand.Option{
 		sshcommand.OptionPrivateKey{Value: h.IdentityFilePath},
 		sshcommand.OptionRemotePort{Value: h.RemotePort},
 		sshcommand.OptionLoginName{Value: h.LoginName},

--- a/internal/model/host/host_test.go
+++ b/internal/model/host/host_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestNewHost(t *testing.T) {
 	expectedHost := Host{
+		Command:          "ssh",
 		ID:               1,
 		Title:            "TestTitle",
 		Description:      "TestDescription",
@@ -82,6 +83,7 @@ func TestIsUserDefinedSSHCommand(t *testing.T) {
 		{
 			name: "NOT user defined ssh command",
 			host: Host{
+				Command:          "ssh",
 				Address:          "localhost",
 				RemotePort:       "2222",
 				LoginName:        "root",
@@ -92,6 +94,7 @@ func TestIsUserDefinedSSHCommand(t *testing.T) {
 		{
 			name: "User defined ssh command",
 			host: Host{
+				Command: "ssh",
 				Address: "username@localhost",
 			},
 			expected: fmt.Sprintf("%s%s", osCmdPrefix, "ssh username@localhost"),
@@ -99,6 +102,7 @@ func TestIsUserDefinedSSHCommand(t *testing.T) {
 		{
 			name: "User defined ssh command - other parameters ignored",
 			host: Host{
+				Command:          "ssh",
 				Address:          "username@localhost",
 				RemotePort:       "2222",
 				LoginName:        "root",
@@ -109,6 +113,7 @@ func TestIsUserDefinedSSHCommand(t *testing.T) {
 		{
 			name: "Host loaded from SSH config",
 			host: Host{
+				Command:     "ssh",
 				Address:     "localhost",
 				Title:       "LOCALHOST_ALIAS",
 				StorageType: constant.HostStorageType.SSHConfig,
@@ -134,6 +139,7 @@ func TestCmdSSHConfig(t *testing.T) {
 		{
 			name: "NOT user defined ssh command",
 			host: Host{
+				Command:          "ssh",
 				Address:          "localhost",
 				RemotePort:       "2222",
 				LoginName:        "root",
@@ -144,6 +150,7 @@ func TestCmdSSHConfig(t *testing.T) {
 		{
 			name: "User defined ssh command",
 			host: Host{
+				Command: "ssh",
 				Address: "username@localhost",
 			},
 			expected: fmt.Sprintf("%s%s", osCmdPrefix, "ssh -G username@localhost"),
@@ -151,6 +158,7 @@ func TestCmdSSHConfig(t *testing.T) {
 		{
 			name: "User defined ssh command - other parameters ignored",
 			host: Host{
+				Command:          "ssh",
 				Address:          "username@localhost",
 				RemotePort:       "2222",
 				LoginName:        "root",
@@ -161,6 +169,7 @@ func TestCmdSSHConfig(t *testing.T) {
 		{
 			name: "Host loaded from SSH config",
 			host: Host{
+				Command:     "ssh",
 				Address:     "localhost",
 				Title:       "LOCALHOST_ALIAS",
 				StorageType: constant.HostStorageType.SSHConfig,

--- a/internal/model/sshcommand/command.go
+++ b/internal/model/sshcommand/command.go
@@ -6,10 +6,8 @@ import (
 	"github.com/grafviktor/goto/internal/model/sshconfig"
 )
 
-var baseCmd = BaseCMD()
-
 // ConnectCommand - builds ssh command to connect to a remote host.
-func ConnectCommand(options ...Option) string {
+func ConnectCommand(baseCmd string, options ...Option) string {
 	sb := strings.Builder{}
 	sb.WriteString(baseCmd)
 
@@ -25,7 +23,7 @@ func ConnectCommand(options ...Option) string {
 }
 
 // LoadConfigCommand - builds ssh command to load config from ssh_config file.
-func LoadConfigCommand(options ...Option) string {
+func LoadConfigCommand(baseCmd string, options ...Option) string {
 	sb := strings.Builder{}
 	sb.WriteString(baseCmd)
 

--- a/internal/model/sshcommand/option_test.go
+++ b/internal/model/sshcommand/option_test.go
@@ -117,7 +117,7 @@ func Test_ConnectCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := ConnectCommand(tt.options...)
+			actual := ConnectCommand("ssh", tt.options...)
 			// Use Contains in order to pass Windows tests. On Windows,
 			// the command starts from 'cmd /c ssh' instead of just 'ssh'
 			require.Contains(t, actual, tt.expectedResult)
@@ -128,7 +128,7 @@ func Test_ConnectCommand(t *testing.T) {
 	state.Create(context.TODO(),
 		application.Configuration{SSHConfigFilePath: "~/.ssh/custom_config"},
 		&mocklogger.Logger{})
-	actual := ConnectCommand(OptionAddress{Value: "example.com"})
+	actual := ConnectCommand("ssh", OptionAddress{Value: "example.com"})
 	require.Contains(t, actual, `ssh example.com -F "~/.ssh/custom_config"`)
 }
 
@@ -152,7 +152,7 @@ func Test_LoadConfigCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := LoadConfigCommand(tt.option)
+			actual := LoadConfigCommand("ssh", tt.option)
 			// Use Contains in order to pass Windows tests. On Windows,
 			// the command starts from 'cmd /c ssh' instead of just 'ssh'
 			require.Contains(t, actual, tt.expectedResult)
@@ -162,7 +162,7 @@ func Test_LoadConfigCommand(t *testing.T) {
 	// Repeat the first test with a custom SSH config file path
 	mockLogger := mocklogger.Logger{}
 	state.Create(context.TODO(), application.Configuration{SSHConfigFilePath: "~/.ssh/custom_config"}, &mockLogger)
-	actual := LoadConfigCommand(tests[0].option)
+	actual := LoadConfigCommand("ssh", tests[0].option)
 	// Should use contains because on Windows version the command starts from 'cmd /c ...'
 	require.Contains(t, actual, `ssh -G example.com -F "~/.ssh/custom_config"`)
 }

--- a/internal/storage/yaml_file.go
+++ b/internal/storage/yaml_file.go
@@ -130,6 +130,11 @@ func (s *yamlFile) GetAll() ([]model.Host, error) {
 		s.nextID++
 		wrapped.Host.ID = s.nextID
 
+		// Set default command if empty
+		if wrapped.Host.Command == "" {
+			wrapped.Host.Command = "ssh"
+		}
+
 		// Maintain an internal map which is keyed by int
 		s.innerStorage[s.nextID] = wrapped
 	}

--- a/internal/ui/component/hostlist/hostlist.go
+++ b/internal/ui/component/hostlist/hostlist.go
@@ -550,7 +550,7 @@ func (m *ListModel) constructProcessCmd(processType constant.ProcessType) tea.Cm
 		return message.TeaCmd(message.ErrorOccurred{Err: errors.New(itemNotSelectedErrMsg)})
 	}
 
-	if host.SSHHostConfig == nil {
+	if host.Command == "ssh" && host.SSHHostConfig == nil {
 		errorText := fmt.Sprintf("[UI] SSH config is not set for host ID='%d', Title='%s'", host.ID, host.Title)
 		m.logger.Error(errorText)
 		return message.TeaCmd(message.ErrorOccurred{Err: errors.New(errorText)})

--- a/internal/ui/component/hostlist/hostlist_test.go
+++ b/internal/ui/component/hostlist/hostlist_test.go
@@ -34,6 +34,7 @@ func TestListModel_Init(t *testing.T) {
 		message.HostSelected{HostID: 1},
 		message.RunProcessSSHLoadConfig{
 			Host: host.Host{
+				Command:          "ssh",
 				ID:               1,
 				Title:            "Mock Host 1",
 				Description:      "",
@@ -161,6 +162,7 @@ func TestRemoveItem(t *testing.T) {
 				message.HostSelected{HostID: 2},
 				message.RunProcessSSHLoadConfig{
 					Host: host.Host{
+						Command:          "ssh",
 						ID:               2,
 						Title:            "Mock Host 2",
 						Description:      "",
@@ -188,6 +190,7 @@ func TestRemoveItem(t *testing.T) {
 				message.HostSelected{HostID: 2},
 				message.RunProcessSSHLoadConfig{
 					Host: host.Host{
+						Command:          "ssh",
 						ID:               2,
 						Title:            "Mock Host 2",
 						Description:      "",
@@ -361,6 +364,7 @@ func TestExitRemoveItemMode(t *testing.T) {
 		message.HostSelected{HostID: 1},
 		message.RunProcessSSHLoadConfig{
 			Host: host.Host{
+				Command:          "ssh",
 				ID:               1,
 				Title:            "Mock Host 1",
 				Description:      "",
@@ -594,6 +598,7 @@ func TestUpdate_HostUpdated(t *testing.T) {
 	require.Equal(t, "Mock Host 1", lm.Items()[0].(ListItemHost).Title())
 
 	updatedHost := host.Host{
+		Command:          "ssh",
 		ID:               1,
 		Title:            "Mock Host 11",
 		Description:      "Mock Host Updated",
@@ -609,6 +614,7 @@ func TestUpdate_HostUpdated(t *testing.T) {
 
 	// Also check that host is inserted into a correct position of the hostlist model
 	updatedHost = host.Host{
+		Command:          "ssh",
 		ID:               1,
 		Title:            "zzz", // Title is now updated, the host should be positioned at the last index
 		Description:      "Mock Host Updated",
@@ -633,6 +639,7 @@ func TestUpdate_HostCreated(t *testing.T) {
 	require.Equal(t, "Mock Host 1", lm.Items()[0].(ListItemHost).Title())
 
 	createdHost1 := host.Host{
+		Command:          "ssh",
 		ID:               999,
 		Title:            "AAA new host", // Should be positioned first
 		Description:      "Mock Host Updated",
@@ -649,6 +656,7 @@ func TestUpdate_HostCreated(t *testing.T) {
 
 	// Also check that host is inserted into a correct position of the hostlist model
 	createdHost2 := host.Host{
+		Command:          "ssh",
 		ID:               666,
 		Title:            "ZZZ new host", // Should be positioned at last index
 		Description:      "Mock Host Updated",


### PR DESCRIPTION
Hi, I extend the definition of model `host` with a `Command` field, which default is "ssh" obviously.

I need this since, I am use `tsh` command with some hosts. So, for some hosts, we can redefine the Command with `tsh --proxy=tp.example.com --user=myname ssh`. Luckly, the following arguments almost align with `ssh` command like:

- `-J jumphost`
- `-l login`
- etc

So, please consider accept this patch.