### PR TITLE
fix(sshconfig): skip orphan sub-option tokens to avoid nil-deref panic (#142)

### DIFF
--- a/internal/storage/sshconfig/parser.go
+++ b/internal/storage/sshconfig/parser.go
@@ -43,9 +43,9 @@ func (p *Parser) Parse() ([]model.Host, error) {
 
 	for _, token := range hostTokens {
 		// Every non-Host token decorates the current host. If the lexer
-		// emitted a sub-option (e.g. HostName) before any Host line — which
+		// emitted a sub-option (e.g. HostName) before any Host line, which
 		// happens when the ssh config has leading whitespace on Host lines
-		// (#142) — currentHost is still nil and dereferencing it crashes
+		// (#142), currentHost is still nil and dereferencing it crashes
 		// the TUI. Skip the orphan token instead of panicking.
 		if token.kind != tokenKind.Host && p.currentHost == nil {
 			continue

--- a/internal/storage/sshconfig/parser.go
+++ b/internal/storage/sshconfig/parser.go
@@ -42,11 +42,6 @@ func (p *Parser) Parse() ([]model.Host, error) {
 	p.foundHosts = nil
 
 	for _, token := range hostTokens {
-		// Every non-Host token decorates the current host. If the lexer
-		// emitted a sub-option (e.g. HostName) before any Host line, which
-		// happens when the ssh config has leading whitespace on Host lines
-		// (#142), currentHost is still nil and dereferencing it crashes
-		// the TUI. Skip the orphan token instead of panicking.
 		if token.kind != tokenKind.Host && p.currentHost == nil {
 			continue
 		}

--- a/internal/storage/sshconfig/parser.go
+++ b/internal/storage/sshconfig/parser.go
@@ -42,6 +42,14 @@ func (p *Parser) Parse() ([]model.Host, error) {
 	p.foundHosts = nil
 
 	for _, token := range hostTokens {
+		// Every non-Host token decorates the current host. If the lexer
+		// emitted a sub-option (e.g. HostName) before any Host line — which
+		// happens when the ssh config has leading whitespace on Host lines
+		// (#142) — currentHost is still nil and dereferencing it crashes
+		// the TUI. Skip the orphan token instead of panicking.
+		if token.kind != tokenKind.Host && p.currentHost == nil {
+			continue
+		}
 		switch token.kind {
 		case tokenKind.Host:
 			// New host found, append current host if it is valid.

--- a/internal/storage/sshconfig/parser_test.go
+++ b/internal/storage/sshconfig/parser_test.go
@@ -114,3 +114,35 @@ func TestParser_Parse_NoLexer(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, hosts)
 }
+
+// TestParser_Parse_OrphanSubOptionDoesNotPanic regression-tests #142:
+// when the ssh config file has leading whitespace on Host lines, the lexer
+// emits sub-option tokens (Hostname, User, etc.) BEFORE any Host token, so
+// p.currentHost is still nil and the original switch dereferenced it,
+// crashing the TUI with a nil pointer panic.
+func TestParser_Parse_OrphanSubOptionDoesNotPanic(t *testing.T) {
+	lexer := &mockLexer{
+		tokens: []SSHToken{
+			// Lexer emits these because matchToken("Host", false) rejects
+			// indented "Host" lines, leaving "HostName" indented and matched.
+			{kind: tokenKind.Hostname, value: "orphan.example.com"},
+			{kind: tokenKind.User, value: "orphan"},
+			// Then a properly-indented block parses normally.
+			{kind: tokenKind.Host, value: "good"},
+			{kind: tokenKind.Hostname, value: "good.example.com"},
+		},
+	}
+	parser := NewParser(lexer, &mocklogger.Logger{})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Parse panicked on orphan sub-option tokens: %v", r)
+		}
+	}()
+
+	hosts, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, "good", hosts[0].Title)
+	require.Equal(t, "good.example.com", hosts[0].Address)
+}

--- a/internal/storage/sshconfig/parser_test.go
+++ b/internal/storage/sshconfig/parser_test.go
@@ -115,19 +115,11 @@ func TestParser_Parse_NoLexer(t *testing.T) {
 	require.Nil(t, hosts)
 }
 
-// TestParser_Parse_OrphanSubOptionDoesNotPanic regression-tests #142:
-// when the ssh config file has leading whitespace on Host lines, the lexer
-// emits sub-option tokens (Hostname, User, etc.) BEFORE any Host token, so
-// p.currentHost is still nil and the original switch dereferenced it,
-// crashing the TUI with a nil pointer panic.
 func TestParser_Parse_OrphanSubOptionDoesNotPanic(t *testing.T) {
 	lexer := &mockLexer{
 		tokens: []SSHToken{
-			// Lexer emits these because matchToken("Host", false) rejects
-			// indented "Host" lines, leaving "HostName" indented and matched.
 			{kind: tokenKind.Hostname, value: "orphan.example.com"},
 			{kind: tokenKind.User, value: "orphan"},
-			// Then a properly-indented block parses normally.
 			{kind: tokenKind.Host, value: "good"},
 			{kind: tokenKind.Hostname, value: "good.example.com"},
 		},


### PR DESCRIPTION
Closes #142.

When the ssh config file has leading whitespace on `Host` lines (Windows tooling, accidental indentation, etc.), `lexer.matchToken` rejects them as not-Host because `Host` must be at column 0; the indented `HostName`/`User`/etc. on the following lines then tokenize before any Host. In the parser switch, every sub-option case dereferences `p.currentHost`, which is still nil, and the TUI crashes with `runtime error: invalid memory address or nil pointer dereference` at `parser.go:53`.

Skips orphan sub-option tokens that arrive without a preceding Host token. The properly-indented blocks downstream still parse normally.

Regression test `TestParser_Parse_OrphanSubOptionDoesNotPanic` feeds a token stream that mimics the lexer output for the attached `ssh.config.bug.txt`: orphan `Hostname`/`User` tokens followed by a well-formed block. The test panics on `develop` and passes after the fix.