### PR TITLE
[Bug] nil pointer dereference when parsing ssh config with incorrect formatting bug

### DIFF
--- a/e2e/11_ssh_config_weird_format.config
+++ b/e2e/11_ssh_config_weird_format.config
@@ -32,6 +32,17 @@ Host test
 Host nohostname
     User root
 
+# See bugfix 142
+Host bugfix_142_1
+HostName 127.0.0.1
+User root
+
+# See bugfix 142
+  Host bugfix_142_2
+HostName 127.0.0.1
+User root
+Port 2222
+
 # Host with weird spacing
 Host       weird-host
         HostName     10.0.0.5

--- a/e2e/11_ssh_config_weird_format.tape
+++ b/e2e/11_ssh_config_weird_format.tape
@@ -8,7 +8,9 @@ Type z
 Down
 Enter
 
-# Go to the very end of the list
+# Go to the very end of the list and exit the application.
+# After that we check that all hosts were read from the config file
+# by comparing selected host ID in state file and the quantity of hosts in ssh config.
 Type G
 
 Type "q"

--- a/e2e/expected/11_ssh_config_weird_format_state.yaml
+++ b/e2e/expected/11_ssh_config_weird_format_state.yaml
@@ -1,5 +1,5 @@
 group: ssh_config
 screen_layout: description
-selected: 9
+selected: 11
 enable_ssh_config: true
 theme: default

--- a/internal/storage/sshconfig/lexer.go
+++ b/internal/storage/sshconfig/lexer.go
@@ -193,38 +193,39 @@ func stripInlineComments(line string) string {
 	return line
 }
 
-func matchToken(line, prefix string) bool {
+func matchToken(line, token string) bool {
+	// Remove leading and trailing whitespace: "  User root" -> "User root"
+	line = strings.TrimSpace(line)
 	if utils.StringEmpty(&line) {
 		return false
 	}
 
-	if len(prefix) >= len(line) {
+	// If token prefix is longer than the line itself, it can't match.
+	if len(token) >= len(line) {
 		return false
 	}
 
-	if !isTokenFollowedDelimiter(line, prefix) {
+	if !isTokenFollowedDelimiter(line, token) {
 		return false
 	}
 
-	return strings.HasPrefix(strings.ToLower(line), strings.ToLower(prefix))
+	return strings.HasPrefix(strings.ToLower(line), strings.ToLower(token))
 }
 
-// func isTokenIndented(str string) bool {
-// 	return len(str) > 0 && (str[0] == ' ' || str[0] == '\t')
-// }
-
-func isTokenFollowedDelimiter(str, prefix string) bool {
-	prefixLen := len(prefix)
+func isTokenFollowedDelimiter(line, token string) bool {
+	prefixLen := len(token)
 	delimiters := []byte{' ', '\t'}
 
 	// Should support metadata token which ends with space or colon.
 	// For instance "# GG:GROUP value" or "# GG:GROUP: value" are valid
-	if strings.HasPrefix(str, "# GG:") {
+	if strings.HasPrefix(line, "# GG:") {
 		delimiters = append(delimiters, ':')
 	}
 
+	// Check if token is followed one of the delimiters. For example,
+	// "User root" and "User\troot" are valid, but "User=root" is not.
 	_, found := lo.Find(delimiters, func(d byte) bool {
-		return str[prefixLen] == d
+		return line[prefixLen] == d
 	})
 
 	return found

--- a/internal/storage/sshconfig/lexer.go
+++ b/internal/storage/sshconfig/lexer.go
@@ -103,6 +103,7 @@ func (l *Lexer) loadFromDataSource(
 		}
 
 		line = stripInlineComments(line)
+		line = strings.TrimSpace(line)
 		token := l.readToken(line)
 
 		if token.kind == tokenKind.IncludeFile {
@@ -134,21 +135,21 @@ func (l *Lexer) loadFromDataSource(
 func (l *Lexer) readToken(line string) SSHToken {
 	var token SSHToken
 	switch {
-	case matchToken(line, "User", true):
+	case matchToken(line, "User"):
 		token = l.usernameToken(line)
-	case matchToken(line, "HostName", true):
+	case matchToken(line, "HostName"):
 		token = l.hostnameToken(line)
-	case matchToken(line, "Host", false):
+	case matchToken(line, "Host"):
 		token = l.hostToken(line)
-	case matchToken(line, "Port", true):
+	case matchToken(line, "Port"):
 		token = l.networkPortToken(line)
-	case matchToken(line, "Include", false):
+	case matchToken(line, "Include"):
 		token = l.keyValuesToken(tokenKind.IncludeFile, line)
-	case matchToken(line, "IdentityFile", true):
+	case matchToken(line, "IdentityFile"):
 		token = l.identityFileToken(line)
-	case matchToken(line, "# GG:GROUP", true):
+	case matchToken(line, "# GG:GROUP"):
 		token = l.metaDataToken(tokenKind.Group, line)
-	case matchToken(line, "# GG:DESCRIPTION", true):
+	case matchToken(line, "# GG:DESCRIPTION"):
 		token = l.metaDataToken(tokenKind.Description, line)
 	default:
 		token = SSHToken{kind: tokenKind.Unsupported}
@@ -189,17 +190,13 @@ func stripInlineComments(line string) string {
 	return line
 }
 
-func matchToken(line, prefix string, shouldBeIndented bool) bool {
+func matchToken(line, prefix string) bool {
 	trimmedLine := strings.TrimSpace(line)
 	if utils.StringEmpty(&trimmedLine) {
 		return false
 	}
 
 	if len(prefix) >= len(trimmedLine) {
-		return false
-	}
-
-	if isTokenIndented(line) != shouldBeIndented {
 		return false
 	}
 

--- a/internal/storage/sshconfig/lexer.go
+++ b/internal/storage/sshconfig/lexer.go
@@ -2,10 +2,12 @@ package sshconfig
 
 import (
 	"bufio"
+	"errors"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -103,7 +105,6 @@ func (l *Lexer) loadFromDataSource(
 		}
 
 		line = stripInlineComments(line)
-		line = strings.TrimSpace(line)
 		token := l.readToken(line)
 
 		if token.kind == tokenKind.IncludeFile {
@@ -133,6 +134,8 @@ func (l *Lexer) loadFromDataSource(
 }
 
 func (l *Lexer) readToken(line string) SSHToken {
+	line = strings.TrimSpace(line)
+
 	var token SSHToken
 	switch {
 	case matchToken(line, "User"):
@@ -191,25 +194,24 @@ func stripInlineComments(line string) string {
 }
 
 func matchToken(line, prefix string) bool {
-	trimmedLine := strings.TrimSpace(line)
-	if utils.StringEmpty(&trimmedLine) {
+	if utils.StringEmpty(&line) {
 		return false
 	}
 
-	if len(prefix) >= len(trimmedLine) {
+	if len(prefix) >= len(line) {
 		return false
 	}
 
-	if !isTokenFollowedDelimiter(trimmedLine, prefix) {
+	if !isTokenFollowedDelimiter(line, prefix) {
 		return false
 	}
 
-	return strings.HasPrefix(strings.ToLower(trimmedLine), strings.ToLower(prefix))
+	return strings.HasPrefix(strings.ToLower(line), strings.ToLower(prefix))
 }
 
-func isTokenIndented(str string) bool {
-	return len(str) > 0 && (str[0] == ' ' || str[0] == '\t')
-}
+// func isTokenIndented(str string) bool {
+// 	return len(str) > 0 && (str[0] == ' ' || str[0] == '\t')
+// }
 
 func isTokenFollowedDelimiter(str, prefix string) bool {
 	prefixLen := len(prefix)
@@ -241,8 +243,7 @@ func (l *Lexer) hostToken(line string) SSHToken {
 	}
 }
 
-func (l *Lexer) usernameToken(rawLine string) SSHToken {
-	line := strings.TrimSpace(rawLine)
+func (l *Lexer) usernameToken(line string) SSHToken {
 	key, value, err := parseKeyValuesLine(line)
 	if err != nil {
 		return SSHToken{kind: tokenKind.Unsupported}
@@ -261,8 +262,7 @@ func (l *Lexer) usernameToken(rawLine string) SSHToken {
 
 const maxHostnameLength = 253
 
-func (l *Lexer) hostnameToken(rawLine string) SSHToken {
-	line := strings.TrimSpace(rawLine)
+func (l *Lexer) hostnameToken(line string) SSHToken {
 	key, value, err := parseKeyValuesLine(line)
 	if err != nil {
 		return SSHToken{kind: tokenKind.Unsupported}
@@ -283,8 +283,7 @@ func (l *Lexer) hostnameToken(rawLine string) SSHToken {
 	}
 }
 
-func (l *Lexer) networkPortToken(rawLine string) SSHToken {
-	line := strings.TrimSpace(rawLine)
+func (l *Lexer) networkPortToken(line string) SSHToken {
 	key, value, err := parseKeyValuesLine(line)
 	if err != nil {
 		return SSHToken{kind: tokenKind.Unsupported}
@@ -434,4 +433,25 @@ func (l *Lexer) keyValuesToken(kind tokenEnum, line string) SSHToken {
 		key:   key,
 		value: value,
 	}
+}
+
+/*
+Regex to match exactly two or more words.
+
+"hello world",     // Valid.
+"  foo   bar  ",   // Valid.
+"oneword",         // Invalid.
+"three word test", // Valid.
+"",                // Invalid.
+*/
+var twoWordsRegex = regexp.MustCompile(`^(\S+)\s+(.+)$`)
+
+func parseKeyValuesLine(line string) (string, string, error) {
+	matches := twoWordsRegex.FindStringSubmatch(line)
+	// Ideally it should be a loop, not regex.
+	if len(matches) > 1 {
+		return matches[1], matches[2], nil
+	}
+
+	return "", "", errors.New("not a key value string")
 }

--- a/internal/storage/sshconfig/lexer_test.go
+++ b/internal/storage/sshconfig/lexer_test.go
@@ -200,9 +200,9 @@ func TestLexer_Tokenize_IncludeDepthLimit(t *testing.T) {
 
 func Test_matchToken(t *testing.T) {
 	tests := []struct {
-		str    string
-		prefix string
-		want   bool
+		str   string
+		token string
+		want  bool
 	}{
 		{"Host test", "host", true},
 		{"HOST test", "host", true},
@@ -214,8 +214,8 @@ func Test_matchToken(t *testing.T) {
 		{"\t# GG:GROUP: test", "# GG:GROUP", true},
 	}
 	for _, tt := range tests {
-		if got := matchToken(tt.str, tt.prefix); got != tt.want {
-			t.Errorf("hasPrefixIgnoreCase(%q, %q) = %v, want %v", tt.str, tt.prefix, got, tt.want)
+		if got := matchToken(tt.str, tt.token); got != tt.want {
+			t.Errorf("hasPrefixIgnoreCase(%q, %q) = %v, want %v", tt.str, tt.token, got, tt.want)
 		}
 	}
 }

--- a/internal/storage/sshconfig/lexer_test.go
+++ b/internal/storage/sshconfig/lexer_test.go
@@ -200,24 +200,22 @@ func TestLexer_Tokenize_IncludeDepthLimit(t *testing.T) {
 
 func Test_matchToken(t *testing.T) {
 	tests := []struct {
-		str        string
-		prefix     string
-		identation bool
-		want       bool
+		str    string
+		prefix string
+		want   bool
 	}{
-		{"Host test", "host", false, true},
-		{"\tHost test", "host", false, false},
-		{"HOST test", "host", false, true},
-		{"\tUser alice", "USER", true, true},
-		{" Port 22", "port", true, true},
-		{"\tIdentityFile foo", "identityfile", true, true},
-		{"\tSomethingElse", "host", true, false},
-		{"\t# GG:GROUP test", "# GG:GROUP", true, true},
-		{"\t# GG:GROUP: test", "# GG:GROUP", true, true},
+		{"Host test", "host", true},
+		{"HOST test", "host", true},
+		{"\tUser alice", "USER", true},
+		{" Port 22", "port", true},
+		{"\tIdentityFile foo", "identityfile", true},
+		{"\tSomethingElse", "host", false},
+		{"\t# GG:GROUP test", "# GG:GROUP", true},
+		{"\t# GG:GROUP: test", "# GG:GROUP", true},
 	}
 	for _, tt := range tests {
-		if got := matchToken(tt.str, tt.prefix, tt.identation); got != tt.want {
-			t.Errorf("hasPrefixIgnoreCase(%q, %q, %v) = %v, want %v", tt.str, tt.prefix, tt.identation, got, tt.want)
+		if got := matchToken(tt.str, tt.prefix); got != tt.want {
+			t.Errorf("hasPrefixIgnoreCase(%q, %q) = %v, want %v", tt.str, tt.prefix, got, tt.want)
 		}
 	}
 }

--- a/internal/storage/sshconfig/parser.go
+++ b/internal/storage/sshconfig/parser.go
@@ -43,8 +43,11 @@ func (p *Parser) Parse() ([]model.Host, error) {
 
 	for _, token := range hostTokens {
 		if token.kind != tokenKind.Host && p.currentHost == nil {
+			// Something went wrong - the app assigns values to the current host before it is created. This means that the first token must be Host.
+			p.logger.Error("[SSHCONFIG] Unexpected token %s before host declaration", token.value)
 			continue
 		}
+
 		switch token.kind {
 		case tokenKind.Host:
 			// New host found, append current host if it is valid.

--- a/internal/storage/sshconfig/utils.go
+++ b/internal/storage/sshconfig/utils.go
@@ -4,7 +4,6 @@
 package sshconfig
 
 import (
-	"errors"
 	"net/http"
 	"os"
 	"regexp"
@@ -52,27 +51,6 @@ var hostnameRegex = regexp.MustCompile(
 
 func isNetworkPortNumberValid(port int) bool {
 	return port >= 0 && port <= 65535
-}
-
-/*
-Regex to match exactly two or more words.
-
-"hello world",     // Valid.
-"  foo   bar  ",   // Valid.
-"oneword",         // Invalid.
-"three word test", // Valid.
-"",                // Invalid.
-*/
-var twoWordsRegex = regexp.MustCompile(`^(\S+)\s+(.+)$`)
-
-func parseKeyValuesLine(line string) (string, string, error) {
-	matches := twoWordsRegex.FindStringSubmatch(line)
-	// Ideally it should be a loop, not regex.
-	if len(matches) > 1 {
-		return matches[1], matches[2], nil
-	}
-
-	return "", "", errors.New("not a key value string")
 }
 
 func isTextFileMime(filename string) bool {

--- a/internal/ui/ui_error_win_test.go
+++ b/internal/ui/ui_error_win_test.go
@@ -7,8 +7,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/grafviktor/goto/internal/testutils/mocklogger"
 	"golang.org/x/sys/windows"
+
+	"github.com/grafviktor/goto/internal/testutils/mocklogger"
 )
 
 func TestHandleUIStartError(t *testing.T) {


### PR DESCRIPTION
That's a second portion of changes for #142 . This change makes ssh config parser more permissive allowing to parse attributes without proper identation.